### PR TITLE
View - Add `frame-max-width` and `frame-max-height` attributes

### DIFF
--- a/Sources/PhoenixLiveViewNative/ViewTree.swift
+++ b/Sources/PhoenixLiveViewNative/ViewTree.swift
@@ -159,12 +159,20 @@ private extension View {
     private func frame(from element: Element) -> some View {
         var width: CGFloat?
         var height: CGFloat?
+        var maxWidth: CGFloat?
+        var maxHeight: CGFloat?
         var alignment: Alignment
         if let s = element.attrIfPresent("frame-width"), let f = Double(s) {
             width = f
         }
         if let s = element.attrIfPresent("frame-height"), let f = Double(s) {
             height = f
+        }
+        if element.attrIfPresent("frame-max-width") == "infinity" {
+            maxWidth = .infinity
+        }
+        if element.attrIfPresent("frame-max-height") == "infinity" {
+            maxHeight = .infinity
         }
         switch element.attrIfPresent("frame-alignment") {
         case "top-leading":
@@ -196,7 +204,9 @@ private extension View {
         default:
             alignment = .center
         }
-        return self.frame(width: width, height: height, alignment: alignment)
+        return self
+            .frame(width: width, height: height)
+            .frame(maxWidth: maxWidth, maxHeight: maxHeight, alignment: alignment)
     }
     
     private func padding(from element: Element) -> some View {


### PR DESCRIPTION
Adds `maxWidth` and `maxHeight` to the set of supported frame attributes. This is sometimes necessary to correctly align text within stacks, for example:

```heex
<vstack>
  <list style="inset-grouped">
    <%= for {room, population} <- @rooms do %>
      <navigationlink id={"room_#{room.id}"} data-phx-link="redirect" data-phx-link-state="push" data-phx-href={Routes.live_path(@socket, NarwinChatWeb.ChatLive, room.id)}>
        <vstack>
          <hstack frame-alignment="top" pad-top="8" pad-bottom="2" list-row-inset="0">
            <text><%= room.name %></text>
            <spacer />
            <text><%= population %> <%= Inflex.inflect("person", population) %></text>
          </hstack>
          <hstack frame-alignment="leading" frame-max-width="infinity" pad-bottom="8">
            <% # frame-alignment is "leading" so text should be left-aligned %>
            <text font="caption"><%= room.description %></text>
          </hstack>
        </vstack>
      </navigationlink>
    <% end %>
  </list>
</vstack>
```

Without `frame-max-width` support (wrong) vs with (correct):

![Screen Shot 2022-08-24 at 1 19 03 PM](https://user-images.githubusercontent.com/5893007/186516209-66694896-f4c7-4d3d-9b89-556ada3c1cc6.png) ![Screen Shot 2022-08-24 at 1 18 07 PM](https://user-images.githubusercontent.com/5893007/186516264-23768e0b-bb9b-4159-b449-a56e98ba17ca.png)

