### PR TITLE
Snapshot Testing

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -37,5 +37,9 @@ let package = Package(
         .testTarget(
             name: "LiveViewNativeTests",
             dependencies: ["LiveViewNative"]),
+        .testTarget(
+            name: "RenderingTests",
+            dependencies: ["LiveViewNative"]
+        )
     ]
 )

--- a/Tests/RenderingTests/TextTests.swift
+++ b/Tests/RenderingTests/TextTests.swift
@@ -36,7 +36,7 @@ final class TextTests: XCTestCase {
             "black": .black,
         ]
         for (name, weight) in allWeights {
-            try assertMatch(#"<text font="body" font-weight="\#(name)">Hello, world!</text>"#) {
+            try assertMatch(name: "weight-\(name)", #"<text font="body" font-weight="\#(name)">Hello, world!</text>"#) {
                 Text("Hello, world!").font(.system(.body, weight: weight))
             }
         }

--- a/Tests/RenderingTests/TextTests.swift
+++ b/Tests/RenderingTests/TextTests.swift
@@ -1,0 +1,51 @@
+//
+//  TextTests.swift
+//  
+//
+//  Created by Carson Katri on 1/10/23.
+//
+
+import XCTest
+import SwiftUI
+@testable import LiveViewNative
+
+@MainActor
+final class TextTests: XCTestCase {
+    func testSimple() throws {
+        try assertMatch("<text>Hello, world!</text>") {
+            Text("Hello, world!")
+        }
+    }
+    func testStyles() throws {
+        for style in Font.TextStyle.allCases {
+            try assertMatch(#"<text font="\#(style)">Hello, world!</text>"#) {
+                Text("Hello, world!").font(.system(style, weight: .regular))
+            }
+        }
+    }
+    func testWeights() throws {
+        let allWeights: [String:Font.Weight] = [
+            "ultraLight": .ultraLight,
+            "thin": .thin,
+            "light": .light,
+            "regular": .regular,
+            "medium": .medium,
+            "semibold": .semibold,
+            "bold": .bold,
+            "heavy": .heavy,
+            "black": .black,
+        ]
+        for (name, weight) in allWeights {
+            try assertMatch(#"<text font="body" font-weight="\#(name)">Hello, world!</text>"#) {
+                Text("Hello, world!").font(.system(.body, weight: weight))
+            }
+        }
+    }
+    func testColor() throws {
+        for color in [Color.primary, Color.red, Color.blue] {
+            try assertMatch(#"<text color="system-\#(color)">Hello, world!</text>"#) {
+                Text("Hello, world!").foregroundColor(color)
+            }
+        }
+    }
+}

--- a/Tests/RenderingTests/XCTestManifests.swift
+++ b/Tests/RenderingTests/XCTestManifests.swift
@@ -1,0 +1,15 @@
+//
+//  XCTestManifests.swift
+//  
+//
+//  Created by Carson Katri on 1/10/23.
+//
+
+import XCTest
+
+#if !canImport(ObjectiveC)
+public func allTests() -> [XCTestCaseEntry] {
+    return [
+    ]
+}
+#endif

--- a/Tests/RenderingTests/assertMatch.swift
+++ b/Tests/RenderingTests/assertMatch.swift
@@ -1,0 +1,41 @@
+//
+//  assertMatch.swift
+//  
+//
+//  Created by Carson Katri on 1/10/23.
+//
+
+import XCTest
+import SwiftUI
+import Foundation
+@testable import LiveViewNative
+import LiveViewNativeCore
+
+@MainActor
+func assertMatch(
+    _ markup: String,
+    _ function: String = #function,
+    _ file: String = #file,
+    _ line: Int = #line,
+    @ViewBuilder _ view: () -> some View
+) throws {
+    let coordinator = LiveViewCoordinator(URL(string: "http://localhost")!)
+    let document = try LiveViewNativeCore.Document.parse(markup)
+    let viewTree = coordinator.builder.fromNodes(
+        document[document.root()].children(),
+        context: LiveContext(coordinator: coordinator, url: coordinator.currentURL)
+    ).environment(\.coordinatorEnvironment, CoordinatorEnvironment(coordinator, document: document))
+    let markupImage = ImageRenderer(content: viewTree).uiImage?.pngData()
+    let viewImage = ImageRenderer(content: view()).uiImage?.pngData()
+    
+    if markupImage == viewImage {
+        XCTAssert(true)
+    } else {
+        let infoPath = "\(URL(filePath: file).lastPathComponent):\(line)-\(function)"
+        let markupURL = URL.temporaryDirectory.appendingPathComponent("\(infoPath)_markup", conformingTo: .png)
+        let viewURL = URL.temporaryDirectory.appendingPathComponent("\(infoPath)_view", conformingTo: .png)
+        try markupImage?.write(to: markupURL)
+        try viewImage?.write(to: viewURL)
+        XCTAssert(false, "Rendered views did not match. Outputs saved to \(markupURL.path()) and \(viewURL.path())")
+    }
+}

--- a/Tests/RenderingTests/assertMatch.swift
+++ b/Tests/RenderingTests/assertMatch.swift
@@ -19,7 +19,7 @@ func assertMatch(
     _ function: StaticString = #function,
     @ViewBuilder _ view: () -> some View
 ) throws {
-    try assertMatch(name: "\(URL(filePath: file).lastPathComponent):\(line)-\(function)", markup, view)
+    try assertMatch(name: "\(URL(filePath: file).lastPathComponent)-\(line)-\(function)", markup, view)
 }
 
 @MainActor

--- a/Tests/RenderingTests/assertMatch.swift
+++ b/Tests/RenderingTests/assertMatch.swift
@@ -14,9 +14,18 @@ import LiveViewNativeCore
 @MainActor
 func assertMatch(
     _ markup: String,
-    _ function: String = #function,
     _ file: String = #file,
     _ line: Int = #line,
+    _ function: StaticString = #function,
+    @ViewBuilder _ view: () -> some View
+) throws {
+    try assertMatch(name: "\(URL(filePath: file).lastPathComponent):\(line)-\(function)", markup, view)
+}
+
+@MainActor
+func assertMatch(
+    name: String,
+    _ markup: String,
     @ViewBuilder _ view: () -> some View
 ) throws {
     let coordinator = LiveViewCoordinator(URL(string: "http://localhost")!)
@@ -31,9 +40,8 @@ func assertMatch(
     if markupImage == viewImage {
         XCTAssert(true)
     } else {
-        let infoPath = "\(URL(filePath: file).lastPathComponent):\(line)-\(function)"
-        let markupURL = URL.temporaryDirectory.appendingPathComponent("\(infoPath)_markup", conformingTo: .png)
-        let viewURL = URL.temporaryDirectory.appendingPathComponent("\(infoPath)_view", conformingTo: .png)
+        let markupURL = URL.temporaryDirectory.appendingPathComponent("\(name)_markup", conformingTo: .png)
+        let viewURL = URL.temporaryDirectory.appendingPathComponent("\(name)_view", conformingTo: .png)
         try markupImage?.write(to: markupURL)
         try viewImage?.write(to: viewURL)
         XCTAssert(false, "Rendered views did not match. Outputs saved to \(markupURL.path()) and \(viewURL.path())")


### PR DESCRIPTION
This adds a new method for testing an expected View tree against the built output.

Here's an example of a test:

https://github.com/liveviewnative/liveview-client-swiftui/blob/2cb9ddbb7b1ff919ad969ecbc4eb0e3a419f8d08/Tests/RenderingTests/TextTests.swift#L14-L18

You provide the markup and an expected View, and it generates snapshots and compares them. If the snapshots match the test will pass, otherwise it will save the images for the developer to compare.