### PR TITLE
Support more `Font`-related attributes on `Text`

### DIFF
--- a/Sources/LiveViewNative/Views/Text.swift
+++ b/Sources/LiveViewNative/Views/Text.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import LiveViewNativeCore
 
 struct Text: View {
     @ObservedElement private var element: ElementNode
@@ -14,62 +15,80 @@ struct Text: View {
     }
     
     public var body: some View {
-        SwiftUI.Text(element.innerText())
-            .font(self.font)
-            .foregroundColor(textColor)
+        if #available(iOS 16.1, *) {
+            SwiftUI.Text(element.innerText())
+                .font(font)
+                .fontWeight(fontWeight)
+                .fontDesign(fontDesign)
+                .foregroundColor(textColor)
+        } else {
+            SwiftUI.Text(element.innerText())
+                .font(font)
+                .fontWeight(fontWeight)
+                .foregroundColor(textColor)
+        }
+    }
+    
+    private func fontTextStyle(for attribute: AttributeName) -> Font.TextStyle? {
+        switch element.attributeValue(for: attribute)?.lowercased() {
+        case "largetitle": return .largeTitle
+        case "title": return .title
+        case "title2": return .title2
+        case "title3": return .title3
+        case "headline": return .headline
+        case "subheadline": return .subheadline
+        case "body": return .body
+        case "callout": return .callout
+        case "footnote": return .footnote
+        case "caption": return .caption
+        case "caption2": return .caption2
+        default: return nil
+        }
+    }
+    
+    private var fontWeight: Font.Weight? {
+        switch element.attributeValue(for: "font-weight")?.lowercased() {
+        case "ultralight": return .ultraLight
+        case "thin": return .thin
+        case "light": return .light
+        case "regular": return .regular
+        case "medium": return .medium
+        case "semibold": return .semibold
+        case "bold": return .bold
+        case "heavy": return .heavy
+        case "black": return .black
+        default: return nil
+        }
+    }
+    private var fontDesign: Font.Design? {
+        switch element.attributeValue(for: "font-design")?.lowercased() {
+        case "default": return .default
+        case "serif": return .serif
+        case "rounded": return .rounded
+        case "monospaced": return .monospaced
+        default: return nil
+        }
     }
     
     private var font: Font? {
-        let font: Font?
-        switch element.attributeValue(for: "font")?.lowercased() {
-        case "largetitle":
-            font = .largeTitle
-        case "title":
-            font = .title
-        case "title2":
-            font = .title2
-        case "title3":
-            font = .title3
-        case "headline":
-            font = .headline
-        case "subheadline":
-            font = .subheadline
-        case "body":
-            font = .body
-        case "callout":
-            font = .callout
-        case "caption":
-            font = .caption
-        case "caption2":
-            font = .caption2
-        case "footnote":
-            font = .footnote
-        default:
-            font = nil
+        if let style = fontTextStyle(for: "font") {
+            return .system(style)
+        } else if let name = element.attributeValue(for: "font"),
+                  let size = element.attributeValue(for: "font-size").flatMap(Double.init) {
+            if let relativeStyle = fontTextStyle(for: "font-relative-to") {
+                return Font.custom(
+                    name,
+                    size: size,
+                    relativeTo: relativeStyle
+                )
+            } else {
+                return Font.custom(name, size: size)
+            }
+        } else if let size = element.attributeValue(for: "font-size").flatMap(Double.init) {
+            return .system(size: size, weight: fontWeight, design: fontDesign)
+        } else {
+            return nil
         }
-        let weight: Font.Weight
-        switch element.attributeValue(for: "font-weight")?.lowercased() {
-        case "black":
-            weight = Font.Weight.black
-        case "bold":
-            weight = Font.Weight.bold
-        case "heavy":
-            weight = Font.Weight.heavy
-        case "light":
-            weight = Font.Weight.light
-        case "regular":
-            weight = Font.Weight.regular
-        case "semibold":
-            weight = Font.Weight.semibold
-        case "thin":
-            weight = Font.Weight.thin
-        case "ultralight":
-            weight = Font.Weight.ultraLight
-        default:
-            weight = Font.Weight.regular
-        }
-        
-        return font?.weight(weight)
     }
     
     private var textColor: Color? {


### PR DESCRIPTION
This makes some changes to the attribute handling in `Text`, to make the following styles possible:

```html
<%!-- Raw --%>
<text>Hello, world!</text>

<%!-- Weight/Design --%>
<text font-weight="ultraLight" font-design="monospaced">Hello, world!</text>

<%!-- Text Style --%>
<text font="largeTitle" font-weight="medium">Hello, world!</text>

<%!-- Custom Font/Size/Relative Style --%>
<text font="Papyrus" font-size="21" font-relative-to="body">Hello, world!</text>
<text font="Georgia" font-weight="heavy" font-size="21">Hello, world!</text>
```

<img width="213" alt="Screenshot 2023-01-10 at 4 17 43 PM" src="https://user-images.githubusercontent.com/13581484/211664892-cedaf0c3-bab0-4fd7-891e-5144dbb1a01a.png">
