### PR TITLE
Support `spacing` on `VStack`/`HStack`

### DIFF
--- a/Sources/LiveViewNative/Views/HStack.swift
+++ b/Sources/LiveViewNative/Views/HStack.swift
@@ -16,7 +16,7 @@ struct HStack<R: CustomRegistry>: View {
     }
 
     public var body: some View {
-        SwiftUI.HStack(alignment: alignment) {
+        SwiftUI.HStack(alignment: alignment, spacing: spacing) {
             context.buildChildren(of: element)
         }
     }
@@ -32,5 +32,11 @@ struct HStack<R: CustomRegistry>: View {
         default:
             fatalError("Invalid value '\(element.attributeValue(for: "alignment")!)' for alignment attribute of <hstack>")
         }
+    }
+    
+    private var spacing: CGFloat? {
+        element.attributeValue(for: "spacing")
+            .flatMap(Double.init)
+            .flatMap(CGFloat.init)
     }
 }

--- a/Sources/LiveViewNative/Views/VStack.swift
+++ b/Sources/LiveViewNative/Views/VStack.swift
@@ -16,7 +16,7 @@ struct VStack<R: CustomRegistry>: View {
     }
 
     public var body: some View {
-        SwiftUI.VStack(alignment: alignment) {
+        SwiftUI.VStack(alignment: alignment, spacing: spacing) {
             context.buildChildren(of: element)
         }
     }
@@ -32,5 +32,11 @@ struct VStack<R: CustomRegistry>: View {
         default:
             fatalError("Invalid value '\(element.attributeValue(for: "alignment")!)' for alignment attribute of <vstack>")
         }
+    }
+    
+    private var spacing: CGFloat? {
+        element.attributeValue(for: "spacing")
+            .flatMap(Double.init)
+            .flatMap(CGFloat.init)
     }
 }


### PR DESCRIPTION
This adds support for the `spacing` attribute on `VStack` and `HStack`. It expects a number that can be initialized with [`Double.init?(_ text: String)`](https://developer.apple.com/documentation/swift/double/init(_:)-5wmm8)