### PR TITLE
Add `Toggle`

### DIFF
--- a/Sources/LiveViewNative/BuiltinRegistry.swift
+++ b/Sources/LiveViewNative/BuiltinRegistry.swift
@@ -46,7 +46,8 @@ struct BuiltinRegistry {
             Shape(element: element, context: context, shape: RoundedRectangle(from: element))
         case "lvn-link":
             Link(element: element, context: context)
-            
+        case "toggle":
+            Toggle(element: element, context: context)
         case "phx-form":
             PhxForm<R>(element: element, context: context)
         case "phx-submit-button":

--- a/Sources/LiveViewNative/ViewModel.swift
+++ b/Sources/LiveViewNative/ViewModel.swift
@@ -206,3 +206,15 @@ extension String: FormValue {
         self = formValue
     }
 }
+
+extension Bool: FormValue {
+    public var formValue: String {
+        self.description
+    }
+    
+    public init?(formValue: String) {
+        guard let value = Bool(formValue)
+        else { return nil }
+        self = value
+    }
+}

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Value Inputs/Toggle.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Value Inputs/Toggle.swift
@@ -1,0 +1,55 @@
+//
+//  Toggle.swift
+//
+//
+//  Created by Carson Katri on 1/17/23.
+//
+
+import SwiftUI
+
+struct Toggle<R: CustomRegistry>: View {
+    @ObservedElement private var element: ElementNode
+    let context: LiveContext<R>
+    
+    @FormState(default: false) var value: Bool
+    
+    init(element: ElementNode, context: LiveContext<R>) {
+        self.context = context
+    }
+    
+    public var body: some View {
+        SwiftUI.Toggle(isOn: $value) {
+            context.buildChildren(of: element)
+        }
+        .applyToggleStyle(
+            element.attributeValue(for: "toggle-style").flatMap(ToggleStyle.init) ?? .automatic
+        )
+    }
+}
+
+fileprivate enum ToggleStyle: String {
+    case automatic
+    case button
+    case `switch`
+#if os(macOS)
+    case checkbox
+#endif
+}
+
+fileprivate extension View {
+    @ViewBuilder
+    func applyToggleStyle(_ style: ToggleStyle) -> some View {
+        switch style {
+        case .automatic:
+            self.toggleStyle(.automatic)
+        case .button:
+            self.toggleStyle(.button)
+        case .`switch`:
+            self.toggleStyle(.switch)
+#if os(macOS)
+        case .checkbox:
+            self.toggleStyle(.checkbox)
+#endif
+        }
+    }
+}


### PR DESCRIPTION
Closes #71

Adds support for `Toggle` using `@FormState`. `Bool` now conforms to `FormValue` as well.

```html
<toggle name="is_on" toggle-style="switch">
    Value: <%= @is_on %>
</toggle>
<toggle name="is_on" toggle-style="button">
    Value: <%= @is_on %>
</toggle>
```


https://user-images.githubusercontent.com/13581484/212990111-4bf84c76-14a6-4342-afa1-3d4c85d859c9.mp4

