### PR TITLE
Use snake_case modifier keys

### DIFF
--- a/Sources/LiveViewNative/BuiltinRegistry.swift
+++ b/Sources/LiveViewNative/BuiltinRegistry.swift
@@ -60,9 +60,9 @@ struct BuiltinRegistry {
     
     enum ModifierType: String {
         case frame
-        case listRowInsets
-        case listRowSeparator
-        case navigationTitle
+        case listRowInsets = "list_row_insets"
+        case listRowSeparator = "list_row_separator"
+        case navigationTitle = "navigation_title"
         case padding
         case tint
     }


### PR DESCRIPTION
Related to https://github.com/liveviewnative/live_view_native_swift_ui/pull/2

Uses `snake_case` names for modifiers instead of converting them to camel case on the backend automatically.