### PR TITLE
Add `Menu` and prototype for slot syntax

### DIFF
--- a/Sources/LiveViewNative/BuiltinRegistry.swift
+++ b/Sources/LiveViewNative/BuiltinRegistry.swift
@@ -60,6 +60,8 @@ struct BuiltinRegistry {
             EditButton()
         case "toggle":
             Toggle(element: element, context: context)
+        case "menu":
+            Menu(element: element, context: context)
         case "phx-form":
             PhxForm<R>(element: element, context: context)
         case "phx-submit-button":

--- a/Sources/LiveViewNative/LiveContext.swift
+++ b/Sources/LiveViewNative/LiveContext.swift
@@ -64,14 +64,14 @@ public struct LiveContext<R: CustomRegistry> {
                 return false
             }
         })
-        let defaultSlotChildren = children.filter({
-            if case let .element(element) = $0.data {
-                return element.namespace != tagName
-            } else {
-                return true
-            }
-        })
         if namedSlotChildren.isEmpty && includeDefaultSlot {
+            let defaultSlotChildren = children.filter({
+                if case let .element(element) = $0.data {
+                    return element.namespace != tagName
+                } else {
+                    return true
+                }
+            })
             return ForEach(defaultSlotChildren.map({ ($0.id, $0.children()) }), id: \.0) { subChildren in
                 coordinator.builder.fromNodes(subChildren.1, context: self)
             }

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Menus/Menu.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Menus/Menu.swift
@@ -1,0 +1,48 @@
+//
+//  Menu.swift
+//  
+//
+//  Created by Carson Katri on 1/19/23.
+//
+
+import SwiftUI
+
+struct Menu<R: CustomRegistry>: View {
+    @ObservedElement private var element: ElementNode
+    let context: LiveContext<R>
+    
+    @FormState(default: false) var value: Bool
+    
+    init(element: ElementNode, context: LiveContext<R>) {
+        self.context = context
+    }
+    
+    public var body: some View {
+        SwiftUI.Menu {
+            context.buildChildren(of: element, withTagName: "content", namespace: "menu")
+        } label: {
+            context.buildChildren(of: element, defaultSlotFor: "menu")
+            context.buildChildren(of: element, withTagName: "label", namespace: "menu")
+        }
+    }
+}
+
+fileprivate enum MenuStyle: String {
+    case automatic
+    case borderlessButton = "borderless-button"
+    case button
+}
+
+fileprivate extension View {
+    @ViewBuilder
+    func applyMenuStyle(_ style: MenuStyle) -> some View {
+        switch style {
+        case .automatic:
+            self.menuStyle(.automatic)
+        case .borderlessButton:
+            self.menuStyle(.borderlessButton)
+        case .button:
+            self.menuStyle(.button)
+        }
+    }
+}

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Menus/Menu.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Menus/Menu.swift
@@ -11,8 +11,6 @@ struct Menu<R: CustomRegistry>: View {
     @ObservedElement private var element: ElementNode
     let context: LiveContext<R>
     
-    @FormState(default: false) var value: Bool
-    
     init(element: ElementNode, context: LiveContext<R>) {
         self.context = context
     }

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Menus/Menu.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Menus/Menu.swift
@@ -19,8 +19,7 @@ struct Menu<R: CustomRegistry>: View {
         SwiftUI.Menu {
             context.buildChildren(of: element, withTagName: "content", namespace: "menu")
         } label: {
-            context.buildChildren(of: element, defaultSlotFor: "menu")
-            context.buildChildren(of: element, withTagName: "label", namespace: "menu")
+            context.buildChildren(of: element, withTagName: "label", namespace: "menu", includeDefaultSlot: true)
         }
     }
 }


### PR DESCRIPTION
Closes #67

This uses the prefixed slot syntax discussed in #142. If/when a custom engine is added, the following could be refactored to allow for a more familiar slot-like syntax (without any changes to the client code):

```html
<menu>
  <menu:label>Change Mode</menu:label>
  <menu:content>
    <%= for item <- 0..5 do %>
      <button>Option #<%= item %></button>
    <% end %>
  </menu:content>
</menu>
```

The engine would synthesize the above when a slot is used outside of a component by looking up at the nearest parent element.

```html
<menu>
  <:label>Change Mode</:label>
  <:content>
    <%= for item <- 0..5 do %>
      <button>Option #<%= item %></button>
    <% end %>
  </:content>
</menu>
```

https://user-images.githubusercontent.com/13581484/214320105-13ff1f22-16fe-414c-b02a-1d237be47a1a.mov