### PR TITLE
Add `Slider`

### DIFF
--- a/Sources/LiveViewNative/BuiltinRegistry.swift
+++ b/Sources/LiveViewNative/BuiltinRegistry.swift
@@ -62,6 +62,8 @@ struct BuiltinRegistry {
             Toggle(element: element, context: context)
         case "menu":
             Menu(element: element, context: context)
+        case "slider":
+            Slider(element: element, context: context)
         case "phx-form":
             PhxForm<R>(element: element, context: context)
         case "phx-submit-button":

--- a/Sources/LiveViewNative/ViewModel.swift
+++ b/Sources/LiveViewNative/ViewModel.swift
@@ -219,3 +219,15 @@ extension Bool: FormValue {
         self = value
     }
 }
+
+extension Double: FormValue {
+    public var formValue: String {
+        self.formatted()
+    }
+    
+    public init?(formValue: String) {
+        guard let value = Double(formValue)
+        else { return nil }
+        self = value
+    }
+}

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Value Inputs/Slider.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Value Inputs/Slider.swift
@@ -1,0 +1,50 @@
+//
+//  Slider.swift
+//  
+//
+//  Created by Carson Katri on 1/24/23.
+//
+
+import SwiftUI
+
+struct Slider<R: CustomRegistry>: View {
+    @ObservedElement private var element: ElementNode
+    let context: LiveContext<R>
+    
+    @FormState(default: 0) var value: Double
+    
+    init(element: ElementNode, context: LiveContext<R>) {
+        self.context = context
+    }
+    
+    public var body: some View {
+        let lowerBound = element.attributeValue(for: "lower-bound").flatMap(Double.init) ?? 0
+        let upperBound = element.attributeValue(for: "upper-bound").flatMap(Double.init) ?? 1
+        if let step = element.attributeValue(for: "step").flatMap(Double.Stride.init) {
+            SwiftUI.Slider(
+                value: $value,
+                in: lowerBound...upperBound,
+                step: step
+            ) {
+                context.buildChildren(of: element, defaultSlotFor: "slider")
+                context.buildChildren(of: element, withTagName: "label", namespace: "slider")
+            } minimumValueLabel: {
+                context.buildChildren(of: element, withTagName: "minimum-value-label", namespace: "slider")
+            } maximumValueLabel: {
+                context.buildChildren(of: element, withTagName: "maximum-value-label", namespace: "slider")
+            }
+        } else {
+            SwiftUI.Slider(
+                value: $value,
+                in: lowerBound...upperBound
+            ) {
+                context.buildChildren(of: element, defaultSlotFor: "slider")
+                context.buildChildren(of: element, withTagName: "label", namespace: "slider")
+            } minimumValueLabel: {
+                context.buildChildren(of: element, withTagName: "minimum-value-label", namespace: "slider")
+            } maximumValueLabel: {
+                context.buildChildren(of: element, withTagName: "maximum-value-label", namespace: "slider")
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #69 

This builds on the prefixed children of #150 

I also added a `FormValue` conformance to `Double`.

```html
<slider name="number" upper-bound={10} step={1}>
  <slider:label>
    <text>Stepped</text>
  </slider:label>
</slider>

<slider name="number" lower-bound={5} upper-bound={10}>
  <text>Smooth</text>

  <slider:minimum-value-label>
    <text>Min</text>
  </slider:minimum-value-label>

  <slider:maximum-value-label>
    <text>Max</text>
  </slider:maximum-value-label>
</slider>
```

https://user-images.githubusercontent.com/13581484/214359261-dfb4bb22-3ff1-4a2a-b93d-29c1178cd028.mov