### PR TITLE
Disconnect live reload socket on disconnect

### DIFF
--- a/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
@@ -135,6 +135,8 @@ public class LiveSessionCoordinator<R: CustomRegistry>: ObservableObject {
         navigationPath.removeAll()
         self.socket?.disconnect()
         self.socket = nil
+        self.liveReloadSocket?.disconnect()
+        self.liveReloadSocket = nil
         // when deliberately disconnect, don't let pending connections continue
         internalState = .notConnected(reconnectAutomatically: false)
     }


### PR DESCRIPTION
This is a minor change to fix an issue with connections being left open when a live reload occurs. The connection list would continue growing every time the app received a reload. Now it stays around 3 connections.

There still seems to be an issue somewhere with leaving connections open, but I haven't found that yet and this seems to fix part of the problem.

### Before
Every time I cause a reload the list continues to grow.

https://user-images.githubusercontent.com/13581484/214864816-91c93465-c7b4-4bd6-a5c5-a61fc884f2f5.mov

### After
Slightly better, but some connections are still being left open.

https://user-images.githubusercontent.com/13581484/214865136-fd43479a-b497-4a7f-b0cd-b4aeaa80a4db.mov