### PR TITLE
Avoid `AnyView` in modifiers

### DIFF
--- a/Sources/LiveViewNative/BuiltinRegistry.swift
+++ b/Sources/LiveViewNative/BuiltinRegistry.swift
@@ -7,6 +7,8 @@
 
 import SwiftUI
 
+/// This protocol provides access to the `ViewModifier` type returned from `decodeModifier` in the `BuiltinRegistry`.
+/// That type is used by `ModifierContainer.builtin`.
 protocol BuiltinRegistryProtocol {
     associatedtype BuiltinModifier: ViewModifier
     associatedtype ModifierType: RawRepresentable where ModifierType.RawValue == String

--- a/Sources/LiveViewNative/BuiltinRegistry.swift
+++ b/Sources/LiveViewNative/BuiltinRegistry.swift
@@ -7,7 +7,13 @@
 
 import SwiftUI
 
-struct BuiltinRegistry {
+protocol BuiltinRegistryProtocol {
+    associatedtype BuiltinModifier: ViewModifier
+    associatedtype ModifierType: RawRepresentable where ModifierType.RawValue == String
+    static func decodeModifier(_ type: ModifierType, from decoder: Decoder) throws -> BuiltinModifier
+}
+
+struct BuiltinRegistry: BuiltinRegistryProtocol {
     
     static let attributeDecoder = JSONDecoder()
     
@@ -89,20 +95,21 @@ struct BuiltinRegistry {
         case tint
     }
     
-    static func decodeModifier(_ type: ModifierType, from decoder: Decoder) throws -> any ViewModifier {
+    @ViewModifierBuilder
+    static func decodeModifier(_ type: ModifierType, from decoder: Decoder) throws -> some ViewModifier {
         switch type {
         case .frame:
-            return try FrameModifier(from: decoder)
+            try FrameModifier(from: decoder)
         case .listRowInsets:
-            return try ListRowInsetsModifier(from: decoder)
+            try ListRowInsetsModifier(from: decoder)
         case .listRowSeparator:
-            return try ListRowSeparatorModifier(from: decoder)
+            try ListRowSeparatorModifier(from: decoder)
         case .navigationTitle:
-            return try NavigationTitleModifier(from: decoder)
+            try NavigationTitleModifier(from: decoder)
         case .padding:
-            return try PaddingModifier(from: decoder)
+            try PaddingModifier(from: decoder)
         case .tint:
-            return try TintModifier(from: decoder)
+            try TintModifier(from: decoder)
         }
     }
 }

--- a/Sources/LiveViewNative/CustomRegistry.swift
+++ b/Sources/LiveViewNative/CustomRegistry.swift
@@ -70,6 +70,10 @@ public protocol CustomRegistry {
     ///
     /// Generally, implementors will use an opaque return type on their ``lookup(_:element:context:)-895au`` implementations and this will be inferred automatically.
     associatedtype CustomView: View = Never
+    /// The type of view modifier this registry returns from the `decodeModifiers` method.
+    ///
+    /// Generally, implementors will use an opaque return type on their ``decodeModifier(_:from:context:)-35xcx`` implementations and this will be inferred automatically.
+    associatedtype CustomModifier: ViewModifier = EmptyModifier
     /// The type of view this registry produces for loading views.
     ///
     /// Generally, implementors will use an opaque return type on their ``loadingView(for:state:)-2uoy9`` implementations and this will be inferred automatically.
@@ -94,7 +98,7 @@ public protocol CustomRegistry {
     /// - Parameter context: The live context in which the view is being built.
     /// - Returns: A struct that implements the `SwiftUI.ViewModifier` protocol.
     /// - Throws: If decoding the modifier fails.
-    static func decodeModifier(_ type: ModifierType, from decoder: Decoder, context: LiveContext<Self>) throws -> any ViewModifier
+    static func decodeModifier(_ type: ModifierType, from decoder: Decoder, context: LiveContext<Self>) throws -> CustomModifier
     
     /// This method is called when it needs a view to display while connecting to the live view.
     ///
@@ -136,9 +140,9 @@ extension CustomRegistry where TagName == EmptyRegistry.None, CustomView == Neve
         fatalError()
     }
 }
-extension CustomRegistry where ModifierType == EmptyRegistry.None {
+extension CustomRegistry where ModifierType == EmptyRegistry.None, CustomModifier == EmptyModifier {
     /// A default implementation that does not provide any custom modifiers. If you omit the ``CustomRegistry/ModifierType`` type alias, this implementation will be used.
-    public static func decodeModifier(_ type: ModifierType, from decoder: Decoder, context: LiveContext<Self>) -> any ViewModifier {
-        fatalError()
+    public static func decodeModifier(_ type: ModifierType, from decoder: Decoder, context: LiveContext<Self>) -> EmptyModifier {
+        EmptyModifier()
     }
 }

--- a/Sources/LiveViewNative/CustomRegistry.swift
+++ b/Sources/LiveViewNative/CustomRegistry.swift
@@ -98,6 +98,7 @@ public protocol CustomRegistry {
     /// - Parameter context: The live context in which the view is being built.
     /// - Returns: A struct that implements the `SwiftUI.ViewModifier` protocol.
     /// - Throws: If decoding the modifier fails.
+    @ViewModifierBuilder
     static func decodeModifier(_ type: ModifierType, from decoder: Decoder, context: LiveContext<Self>) throws -> CustomModifier
     
     /// This method is called when it needs a view to display while connecting to the live view.

--- a/Sources/LiveViewNative/ViewModifierBuilder.swift
+++ b/Sources/LiveViewNative/ViewModifierBuilder.swift
@@ -1,0 +1,55 @@
+//
+//  ViewModifierBuilder.swift
+//
+//
+//  Created by Carson Katri on 2/1/23.
+//
+
+import SwiftUI
+
+@resultBuilder
+public enum ViewModifierBuilder {
+    public static func buildBlock<M>(_ modifier: M) -> M where M: ViewModifier {
+        modifier
+    }
+    
+    public static func buildEither<TrueModifier, FalseModifier>(
+        first: @autoclosure () throws -> TrueModifier
+    ) rethrows -> _ConditionalModifier<TrueModifier, FalseModifier>
+        where TrueModifier: ViewModifier, FalseModifier: ViewModifier
+    {
+        _ConditionalModifier(storage: .trueModifier(try first()))
+    }
+    
+    public static func buildEither<TrueModifier, FalseModifier>(
+        second: @autoclosure () throws -> FalseModifier
+    ) rethrows -> _ConditionalModifier<TrueModifier, FalseModifier>
+        where TrueModifier: ViewModifier, FalseModifier: ViewModifier
+    {
+        _ConditionalModifier(storage: .falseModifier(try second()))
+    }
+}
+
+@frozen public struct _ConditionalModifier<TrueModifier, FalseModifier>: ViewModifier
+    where TrueModifier: ViewModifier, FalseModifier: ViewModifier
+{
+    @usableFromInline
+    @frozen
+    internal enum Storage {
+        case trueModifier(TrueModifier)
+        case falseModifier(FalseModifier)
+    }
+    
+    @usableFromInline
+    internal let storage: Storage
+    
+    @inlinable
+    public func body(content: Content) -> some View {
+        switch storage {
+        case let .trueModifier(modifier):
+            content.modifier(modifier)
+        case let .falseModifier(modifier):
+            content.modifier(modifier)
+        }
+    }
+}

--- a/Sources/LiveViewNative/ViewTree.swift
+++ b/Sources/LiveViewNative/ViewTree.swift
@@ -116,8 +116,10 @@ extension ViewTreeBuilder {
     }
 }
 
-struct ModifierContainer<R: CustomRegistry>: Decodable {
-    let modifier: any ViewModifier
+enum ModifierContainer<R: CustomRegistry>: Decodable {
+    case builtin(BuiltinRegistry.BuiltinModifier)
+    case custom(R.CustomModifier)
+    case error(ErrorModifier)
     
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
@@ -125,23 +127,35 @@ struct ModifierContainer<R: CustomRegistry>: Decodable {
         if let type = R.ModifierType(rawValue: type) {
             let context = decoder.userInfo[.liveContext] as! LiveContext<R>
             do {
-                self.modifier = try R.decodeModifier(type, from: decoder, context: context)
+                self = .custom(try R.decodeModifier(type, from: decoder, context: context))
             } catch {
-                self.modifier = ErrorModifier(type: type.rawValue, error: error)
+                self = .error(ErrorModifier(type: type.rawValue, error: error))
             }
         } else if let type = BuiltinRegistry.ModifierType(rawValue: type) {
             do {
-                self.modifier = try BuiltinRegistry.decodeModifier(type, from: decoder)
+                self = .builtin(try BuiltinRegistry.decodeModifier(type, from: decoder))
             } catch {
-                self.modifier = ErrorModifier(type: type.rawValue, error: error)
+                self = .error(ErrorModifier(type: type.rawValue, error: error))
             }
         } else {
-            self.modifier = ErrorModifier(type: type, error: ViewTreeBuilder<R>.Error.unknownModifierType)
+            self = .error(ErrorModifier(type: type, error: ViewTreeBuilder<R>.Error.unknownModifierType))
         }
     }
     
     enum CodingKeys: String, CodingKey {
         case type
+    }
+    
+    @ViewModifierBuilder
+    var modifier: some ViewModifier {
+        switch self {
+        case let .builtin(modifier):
+            modifier
+        case let .custom(modifier):
+            modifier
+        case let .error(modifier):
+            modifier
+        }
     }
 }
 
@@ -154,7 +168,7 @@ private struct ModifierApplicator<Parent: View, R: CustomRegistry>: View {
     var body: some View {
         let remaining = modifiers[modifiers.index(after: modifiers.startIndex)...]
         // force-unwrap is okay, this view is never  constructed with an empty slice
-        modifiers.first!.modifier.apply(to: parent)
+        parent.modifier(modifiers.first!.modifier)
             .applyModifiers(remaining, context: context)
     }
 }
@@ -167,12 +181,6 @@ private extension View {
         } else {
             ModifierApplicator(parent: self, modifiers: modifiers, context: context)
         }
-    }
-}
-
-private extension ViewModifier {
-    func apply<V: View>(to view: V) -> AnyView {
-        AnyView(view.modifier(self))
     }
 }
 

--- a/Tests/LiveViewNativeTests/DecodeModifiersTest.swift
+++ b/Tests/LiveViewNativeTests/DecodeModifiersTest.swift
@@ -13,14 +13,12 @@ final class DecodeModifiersTest: XCTestCase {
 
     let decoder = JSONDecoder()
     
-    private func assertDecodeModifier<T: ViewModifier & Equatable>(_ json: String, expected: T) throws {
+    private func assertDecodeModifier<T: ViewModifier & Equatable>(_ json: String, expected: T) throws
+    where T: Decodable
+    {
         let data = json.data(using: .utf8)!
-        let container = try decoder.decode(ModifierContainer<EmptyRegistry>.self, from: data)
-        guard let decodedAsT = container.modifier as? T else {
-            XCTFail("Expected modifier of type \(type(of: container.modifier)) to be \(T.self)")
-            return
-        }
-        XCTAssertEqual(decodedAsT, expected)
+        let decoded = try decoder.decode(T.self, from: data)
+        XCTAssertEqual(decoded, expected)
     }
     
     func testDecodeFrame() throws {


### PR DESCRIPTION
This refactors modifier handling to avoid the use of `AnyView`, which could impact performance.

Now, modifiers work more like elements. Custom registries should provide an `applyModifier(_:modifier:to:context:)` method to register custom modifier types:

```swift
struct MyRegistry: CustomRegistry {
  static func applyModifier(_ type: ModifierType, modifier: Modifier<Self>, to content: some View, context: LiveContext<Self>) -> some View {
    switch type {
    case .myModifier:
      content.modifier(MyCustomModifier(from: modifier))
    }
  }
}
```

Note that this will require some changes to the serialization in `live_view_native_swift_ui` (https://github.com/liveviewnative/live_view_native_swift_ui/pull/5), so that each parameter value is encoded as a string, similar to element attributes. These can then be decoded individually as needed.

Let me know your thoughts on these changes.