### PR TITLE
Add `Label`

### DIFF
--- a/Sources/LiveViewNative/BuiltinRegistry.swift
+++ b/Sources/LiveViewNative/BuiltinRegistry.swift
@@ -70,6 +70,8 @@ struct BuiltinRegistry {
 #endif
         case "slider":
             Slider(element: element, context: context)
+        case "label":
+            Label(element: element, context: context)
         case "phx-form":
             PhxForm<R>(element: element, context: context)
         case "phx-submit-button":

--- a/Sources/LiveViewNative/Views/Text Input and Output/Label.swift
+++ b/Sources/LiveViewNative/Views/Text Input and Output/Label.swift
@@ -1,0 +1,53 @@
+//
+//  Label.swift
+//  
+//
+//  Created by Carson Katri on 1/31/23.
+//
+
+import SwiftUI
+
+struct Label<R: CustomRegistry>: View {
+    @ObservedElement private var element: ElementNode
+    let context: LiveContext<R>
+    
+    init(element: ElementNode, context: LiveContext<R>) {
+        self.context = context
+    }
+    
+    public var body: some View {
+        SwiftUI.Label {
+            context.buildChildren(of: element, withTagName: "title", namespace: "label", includeDefaultSlot: true)
+        } icon: {
+            if let systemImage = element.attributeValue(for: "system-image") {
+                SwiftUI.Image(systemName: systemImage)
+            } else {
+                context.buildChildren(of: element, withTagName: "icon", namespace: "label")
+            }
+        }
+        .applyLabelStyle(element.attributeValue(for: "label-style").flatMap(LabelStyle.init) ?? .automatic)
+    }
+}
+
+fileprivate enum LabelStyle: String {
+    case iconOnly = "icon-only"
+    case titleOnly = "title-only"
+    case titleAndIcon = "title-and-icon"
+    case automatic = "automatic"
+}
+
+fileprivate extension View {
+    @ViewBuilder
+    func applyLabelStyle(_ style: LabelStyle) -> some View {
+        switch style {
+        case .iconOnly:
+            self.labelStyle(.iconOnly)
+        case .titleOnly:
+            self.labelStyle(.titleOnly)
+        case .titleAndIcon:
+            self.labelStyle(.titleAndIcon)
+        case .automatic:
+            self.labelStyle(.automatic)
+        }
+    }
+}

--- a/Tests/RenderingTests/TextTests.swift
+++ b/Tests/RenderingTests/TextTests.swift
@@ -11,6 +11,7 @@ import SwiftUI
 
 @MainActor
 final class TextTests: XCTestCase {
+    // MARK: Text
     func testTextSimple() throws {
         try assertMatch("<text>Hello, world!</text>") {
             Text("Hello, world!")
@@ -119,6 +120,7 @@ This is some markdown text [click me](apple.com)
         }
     }
     
+    // MARK: TextField
     func testTextFieldSimple() throws {
         try assertMatch(#"<text-field placeholder="Type here" />"#) {
             TextField("Type here", text: .constant(""))
@@ -133,6 +135,30 @@ This is some markdown text [click me](apple.com)
         }
         try assertMatch(#"<secure-field placeholder="Placeholder" prompt="Prompt" />"#) {
             SecureField("Placeholder", text: .constant(""), prompt: Text("Prompt"))
+        }
+    }
+    
+    // MARK: Label
+    func testLabelSimple() throws {
+        try assertMatch(#"<label system-image="bolt.fill">Lightning<label>"#) {
+            Label("Lightning", systemImage: "bolt.fill")
+        }
+    }
+    
+    func testLabelSlots() throws {
+        try assertMatch(
+            #"""
+            <label>
+                <label:icon><image system-name="bolt.fill" /></label:icon>
+                <label:title><text>Lightning</text></label:title>
+            <label>
+            """#
+        ) {
+            Label {
+                Text("Lightning")
+            } icon: {
+                Image(systemName: "bolt.fill")
+            }
         }
     }
 }


### PR DESCRIPTION
Closes #44

The `icon` and `title` slots can be used to set the content:

```html
<label>
  <:title>
    <text>Lightning</text>
  </:title>
  <:icon>
    <image system-name="bolt.fill" />
  </:icon>
</label>
```

The `system-image` attribute can be used in place of an `icon` slot:

```html
<label system-image="bolt.fill">Lightning</label>
```

A few styles are also available:
```html
<label label-style="icon-only">
  <text>This is ignored</text>
  <:icon>
    <image system-name="bolt.fill" />
  </:icon>
</label>
```

The tests will probably fail until #158 is merged, which contains some fixes for slots.