### PR TITLE
Add `Stepper`

### DIFF
--- a/Sources/LiveViewNative/BuiltinRegistry.swift
+++ b/Sources/LiveViewNative/BuiltinRegistry.swift
@@ -70,6 +70,8 @@ struct BuiltinRegistry {
 #endif
         case "slider":
             Slider(element: element, context: context)
+        case "stepper":
+            Stepper(element: element, context: context)
         case "phx-form":
             PhxForm<R>(element: element, context: context)
         case "phx-submit-button":

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Value Inputs/Stepper.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Value Inputs/Stepper.swift
@@ -1,0 +1,38 @@
+//
+//  Stepper.swift
+//  
+//
+//  Created by Carson Katri on 1/31/23.
+//
+
+import SwiftUI
+
+struct Stepper<R: CustomRegistry>: View {
+    @ObservedElement private var element: ElementNode
+    let context: LiveContext<R>
+    
+    @FormState(default: 0) var value: Double
+    
+    init(element: ElementNode, context: LiveContext<R>) {
+        self.context = context
+    }
+    
+    public var body: some View {
+        let step = element.attributeValue(for: "step").flatMap(Double.init) ?? 1
+        if let lowerBound = element.attributeValue(for: "lower-bound").flatMap(Double.init),
+           let upperBound = element.attributeValue(for: "upper-bound").flatMap(Double.init)
+        {
+            SwiftUI.Stepper(value: $value, in: lowerBound...upperBound, step: step) {
+                label
+            }
+        } else {
+            SwiftUI.Stepper(value: $value, step: step) {
+                label
+            }
+        }
+    }
+    
+    private var label: some View {
+        context.buildChildren(of: element)
+    }
+}

--- a/Tests/RenderingTests/ValueInputTests.swift
+++ b/Tests/RenderingTests/ValueInputTests.swift
@@ -11,6 +11,8 @@ import SwiftUI
 
 @MainActor
 final class ValueInputTests: XCTestCase {
+    // MARK: Slider
+    
     func testSliderSimple() throws {
         try assertMatch(#"<slider />"#, size: .init(width: 100, height: 100)) {
             Slider(value: .constant(0))
@@ -41,9 +43,21 @@ final class ValueInputTests: XCTestCase {
         }
     }
     
+    // MARK: Toggle
+    
     func testToggleSimple() throws {
-        try assertMatch(#"<toggle>Switch</toggle>"#, lifetime: .keepAlways) {
+        try assertMatch(#"<toggle>Switch</toggle>"#) {
             Toggle("Switch", isOn: .constant(false))
+        }
+    }
+    
+    // MARK: Stepper
+    
+    func testStepperSimple() throws {
+        try assertMatch(#"<stepper>Stepper Label</stepper>"#) {
+            Stepper(value: .constant(0)) {
+                Text("Stepper Label")
+            }
         }
     }
 }


### PR DESCRIPTION
Closes #70 

You can specify a `lower-bound`, `upper-bound`, and `step`. The `step` defaults to `1`.

```html
<phx-form id="color-form" phx-change="update_color">
    <circle fill-color={@color} modifiers={@native |> frame(width: 50, height: 50)} />
    <text font="caption" color="system-secondary">
        <%= @r %> <%= @g %> <%= @b %>
    </text>
    <stepper name="r" step={10} upper-bound="255">Red</stepper>
    <stepper name="g" step={10} lower-bound="0" upper-bound="255">Green</stepper>
    <stepper name="b" step="10" lower-bound="0" upper-bound="255">Blue</stepper>
</phx-form>
```

https://user-images.githubusercontent.com/13581484/215889958-a489b93f-60c9-4427-a1e3-c6df05cf9433.mp4

