### PR TITLE
Live bindings and public event handling API

### DIFF
--- a/Sources/LiveViewNative/Coordinators/LiveSessionConfiguration.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveSessionConfiguration.swift
@@ -23,11 +23,6 @@ public struct LiveSessionConfiguration {
     /// The URL session the coordinator will use for performing HTTP and socket requests. By default, this is the shared session.
     public var urlSession: URLSession = .shared
     
-    // Non-final API for internal use only.
-    @_spi(NarwinChat)
-    public var eventHandlersEnabled: Bool = true
-    
-    @_spi(NarwinChat)
     public var liveRedirectsEnabled: Bool = true
     
     /// Constructs a default, empty configuration.

--- a/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
@@ -15,7 +15,7 @@ import LiveViewNativeCore
 
 private let logger = Logger(subsystem: "LiveViewNative", category: "LiveSessionCoordinator")
 
-/// The live view coordinator object handles connecting to Phoenix LiveView on the backend, managing the websocket connection, and transmitting/handling events.
+/// The session coordinator object handles the initial connection, as well as navigation.
 @MainActor
 public class LiveSessionCoordinator<R: CustomRegistry>: ObservableObject {
     @Published internal private(set) var internalState: InternalState = .notConnected(reconnectAutomatically: false)

--- a/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
@@ -16,6 +16,13 @@ private var PUSH_TIMEOUT: Double = 30000
 
 private let logger = Logger(subsystem: "LiveViewNative", category: "LiveViewCoordinator")
 
+/// The live view coordinator manages the connection to a particular LiveView on the backend.
+///
+/// ## Topics
+/// ### LiveView Events
+/// - ``pushEvent(type:event:value:)``
+/// - ``receiveEvent(_:)``
+/// - ``handleEvent(_:handler:)``
 @MainActor
 public class LiveViewCoordinator<R: CustomRegistry>: ObservableObject {
     @Published internal private(set) var internalState: LiveSessionCoordinator<R>.InternalState = .notConnected(reconnectAutomatically: false)
@@ -37,21 +44,21 @@ public class LiveViewCoordinator<R: CustomRegistry>: ObservableObject {
     private var currentConnectionToken: ConnectionAttemptToken?
     private var currentConnectionTask: Task<Void, Error>?
     
-    private var eventHandlers: [String: (Payload) -> Void] = [:]
+    private var eventSubject = PassthroughSubject<(String, Payload), Never>()
+    private var eventHandlers = Set<AnyCancellable>()
     
     init(session: LiveSessionCoordinator<R>, url: URL) {
         self.session = session
         self.url = url
-        self.eventHandlers = [
-            "native_redirect": { [weak self] payload in
-                guard let self,
-                      let redirect = LiveRedirect(from: payload, relativeTo: self.url)
-                else { return }
-                Task {
-                    await session.redirect(redirect)
-                }
+        
+        self.handleEvent("native_redirect") { [weak self] payload in
+            guard let self,
+                  let redirect = LiveRedirect(from: payload, relativeTo: self.url)
+            else { return }
+            Task {
+                await session.redirect(redirect)
             }
-        ]
+        }
     }
     
     /// Pushes a LiveView event with the given name and payload to the server.
@@ -62,7 +69,7 @@ public class LiveViewCoordinator<R: CustomRegistry>: ObservableObject {
     /// - Parameter type: The type of event that is being sent (e.g., `click` or `form`). Note: this is not currently used by the LiveView backend.
     /// - Parameter event: The name of the LiveView event handler that the event is being dispatched to.
     /// - Parameter value: The event value to provide to the backend event handler. The value _must_ be  serializable using ``JSONSerialization``.
-    /// - Throws: `FetchError.eventError` if an error is encountered sending the event or processing it on the backend, `CancellationError` if the coordinator navigates to a different page while the event is being handled
+    /// - Throws: ``LiveConnectionError/eventError(_:)`` if an error is encountered sending the event or processing it on the backend, `CancellationError` if the coordinator navigates to a different page while the event is being handled
     public func pushEvent(type: String, event: String, value: Any) async throws {
         // isValidJSONObject only accepts objects, but we want to check that the value can be serialized as a field of an object
         precondition(JSONSerialization.isValidJSONObject(["a": value]))
@@ -107,16 +114,73 @@ public class LiveViewCoordinator<R: CustomRegistry>: ObservableObject {
         }
     }
     
+    /// Creates a publisher that can be used to listen for server-sent LiveView events.
+    ///
+    /// - Parameter event: The event name that is being listened for.
+    /// - Returns: A publisher that emits event payloads.
+    ///
+    /// To handle events, use the `sink` subscriber:
+    /// ```swift
+    /// myEventHandler = coordinator.receiveEvent("my_event")
+    ///     .sink { payload in
+    ///         print("Received payload: \(payload)")
+    ///     }
+    /// ```
+    /// The `sink` method returns an `AnyCancellable` which can be used to later stop listening for events by calling its `cancel` method.
+    ///
+    /// - Important: `AnyCancellable` will cancel itself upon deinitialization, so you must hold a strong reference to it for the duration you want to keep receiving events. If you want to keep listenting for the lifetime of the coordinator, you may use ``handleEvent(_:handler:)``.
+    ///
+    /// This publisher is _not_ guaranteed to fire on the main thread.
+    /// If you need to perform UI updates, use the `receive(on:)` operator, as shown below.
+    /// ```swift
+    /// coordinator.receiveEvent("my_event")
+    ///     .receive(on: DispatchQueue.main)
+    ///     .sink { payload in
+    ///         myUIObject.value = payload["value"] as! String
+    ///     }
+    ///     .store(in: &cancellables)
+    /// ```
+    ///
+    /// If you are using SwiftUI's `onReceive` modifier, applying `receive(on:)` to the publisher is not necessary.
+    /// ```swift
+    /// struct MyView: View {
+    ///     let context: LiveContext<EmptyRegistry>
+    ///     @State private var text = "Hello"
+    ///     var body: some View {
+    ///         Text(text)
+    ///             .onReceive(context.coordinator.receiveEvent("my_event")) { payload in
+    ///                 self.text = payload["text"] as! String
+    ///             }
+    ///     }
+    /// }
+    /// ```
+    public func receiveEvent(_ event: String) -> some Publisher<Payload, Never> {
+        eventSubject
+            .filter { $0.0 == event }
+            .map(\.1)
+    }
+    
+    /// Permanently registers a handler for a server-sent LiveView event.
+    ///
+    /// - Parameter event: The event name that is being listened for.
+    /// - Parameter handler: A closure to invoke when the coordinator receives an event. The event value is provided as the closure's parameter.
+    ///
+    /// Handlers registered using this method will receive events for the lifetime of the coordinator.
+    /// To create an event listener that can later be cancelled, use ``receiveEvent(_:)``.
+    public func handleEvent(_ event: String, handler: @escaping (Payload) -> Void) {
+        receiveEvent(event)
+            .sink(receiveValue: handler)
+            .store(in: &eventHandlers)
+    }
+    
     private func handleDiff(payload: Payload, baseURL: URL) throws {
-        if session.config.eventHandlersEnabled,
-           let events = payload["e"] as? [[Any]] {
+        if let events = payload["e"] as? [[Any]] {
             for event in events {
                 guard let name = event[0] as? String,
-                      let value = event[1] as? Payload,
-                      let handler = eventHandlers[name] else {
+                      let value = event[1] as? Payload else {
                     continue
                 }
-                handler(value)
+                eventSubject.send((name, value))
             }
         }
         let diff = try RootDiff(from: FragmentDecoder(data: payload))

--- a/Sources/LiveViewNative/Environment.swift
+++ b/Sources/LiveViewNative/Environment.swift
@@ -24,7 +24,7 @@ private struct TextFieldPrimaryActionKey: EnvironmentKey {
 /// Provides access to ``LiveViewCoordinator`` properties via the environment.
 /// This exists to type-erase the coordinator, since environment properties can't be generic.
 struct CoordinatorEnvironment {
-    let pushEvent: (String, String, Any) async throws -> Void
+    let pushEvent: @MainActor (String, String, Any) async throws -> Void
     let elementChanged: AnyPublisher<NodeRef, Never>
     let document: Document
     

--- a/Sources/LiveViewNative/FragmentEncoder.swift
+++ b/Sources/LiveViewNative/FragmentEncoder.swift
@@ -1,0 +1,390 @@
+//
+//  FragmentEncoder.swift
+//  LiveViewNative
+//
+//  Created by Shadowfacts on 1/27/23.
+//
+
+import Foundation
+
+/// An ``Encoder`` implementation that lets us encode something to be later serialized by ``JSONSerialization``
+class FragmentEncoder: Encoder {
+    var future = JSONFuture()
+    
+    var codingPath: [CodingKey]
+    
+    var userInfo: [CodingUserInfoKey : Any] = [:]
+    
+    init(codingPath: [CodingKey] = []) {
+        self.codingPath = codingPath
+    }
+    
+    func unwrap() -> Any? {
+        future.value!.unwrap()
+    }
+    
+    func container<Key>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> where Key : CodingKey {
+        return KeyedEncodingContainer(KeyedFragmentEncodingContainer(future: future, codingPath: codingPath))
+    }
+    
+    func unkeyedContainer() -> UnkeyedEncodingContainer {
+        return UnkeyedFragmentEncodingContainer(future: future, codingPath: codingPath)
+    }
+    
+    func singleValueContainer() -> SingleValueEncodingContainer {
+        return SingleValueFragmentEncodingContainer(future: future, codingPath: codingPath)
+    }
+}
+
+class JSONFuture {
+    var value: JSONValue?
+    
+    init(value: JSONValue? = nil) {
+        self.value = value
+    }
+}
+
+class JSONValue {
+    private var payload: Payload
+    
+    private init(payload: Payload) {
+        self.payload = payload
+    }
+    
+    static func null() -> JSONValue {
+        JSONValue(payload: .null)
+    }
+    
+    static func string(_ s: String) -> JSONValue {
+        JSONValue(payload: .string(s))
+    }
+    
+    static func number(_ n: NSNumber) -> JSONValue {
+        JSONValue(payload: .number(n))
+    }
+    
+    static func emptyArray() -> JSONValue {
+        JSONValue(payload: .array([]))
+    }
+    
+    static func emptyObject() -> JSONValue {
+        JSONValue(payload: .object([:]))
+    }
+    
+    func unwrap() -> Any? {
+        return payload.unwrap()
+    }
+    
+    func arrayCount() -> Int {
+        guard case .array(let a) = payload else {
+            fatalError()
+        }
+        return a.count
+    }
+    
+    func arrayAppend(value: JSONValue) {
+        guard case .array(var a) = payload else {
+            fatalError()
+        }
+        a.append(value)
+        payload = .array(a)
+    }
+    
+    func objectSet(value: JSONValue, forKey key: String) {
+        guard case .object(var d) = payload else {
+            fatalError()
+        }
+        d[key] = value
+        payload = .object(d)
+    }
+    
+    private enum Payload {
+        case null
+        case string(String)
+        case number(NSNumber)
+        case array([JSONValue])
+        case object([String: JSONValue])
+        
+        func unwrap() -> Any? {
+            switch self {
+            case .null:
+                return nil
+            case .string(let s):
+                return s
+            case .number(let n):
+                return n
+            case .array(let a):
+                return a.map { $0.unwrap() }
+            case .object(let o):
+                return o.mapValues { $0.unwrap() }
+            }
+        }
+    }
+}
+
+struct KeyedFragmentEncodingContainer<Key: CodingKey>: KeyedEncodingContainerProtocol {
+    let future: JSONFuture
+    let codingPath: [CodingKey]
+    
+    init(future: JSONFuture, codingPath: [CodingKey]) {
+        self.future = future
+        self.codingPath = codingPath
+        future.value = .emptyObject()
+    }
+    
+    mutating func encodeNil(forKey key: Key) throws {
+        future.value!.objectSet(value: .null(), forKey: key.stringValue)
+    }
+    
+    mutating func encode(_ value: String, forKey key: Key) throws {
+        future.value!.objectSet(value: .string(value), forKey: key.stringValue)
+    }
+    
+    mutating func encode(_ value: Bool, forKey key: Key) throws {
+        future.value!.objectSet(value: .number(value as NSNumber), forKey: key.stringValue)
+    }
+    
+    mutating func encode(_ value: Double, forKey key: Key) throws {
+        future.value!.objectSet(value: .number(value as NSNumber), forKey: key.stringValue)
+    }
+    
+    mutating func encode(_ value: Float, forKey key: Key) throws {
+        future.value!.objectSet(value: .number(value as NSNumber), forKey: key.stringValue)
+    }
+    
+    mutating func encode(_ value: Int, forKey key: Key) throws {
+        future.value!.objectSet(value: .number(value as NSNumber), forKey: key.stringValue)
+    }
+    
+    mutating func encode(_ value: Int8, forKey key: Key) throws {
+        future.value!.objectSet(value: .number(value as NSNumber), forKey: key.stringValue)
+    }
+    
+    mutating func encode(_ value: Int16, forKey key: Key) throws {
+        future.value!.objectSet(value: .number(value as NSNumber), forKey: key.stringValue)
+    }
+    
+    mutating func encode(_ value: Int32, forKey key: Key) throws {
+        future.value!.objectSet(value: .number(value as NSNumber), forKey: key.stringValue)
+    }
+    
+    mutating func encode(_ value: Int64, forKey key: Key) throws {
+        future.value!.objectSet(value: .number(value as NSNumber), forKey: key.stringValue)
+    }
+    
+    mutating func encode(_ value: UInt, forKey key: Key) throws {
+        future.value!.objectSet(value: .number(value as NSNumber), forKey: key.stringValue)
+    }
+    
+    mutating func encode(_ value: UInt8, forKey key: Key) throws {
+        future.value!.objectSet(value: .number(value as NSNumber), forKey: key.stringValue)
+    }
+    
+    mutating func encode(_ value: UInt16, forKey key: Key) throws {
+        future.value!.objectSet(value: .number(value as NSNumber), forKey: key.stringValue)
+    }
+    
+    mutating func encode(_ value: UInt32, forKey key: Key) throws {
+        future.value!.objectSet(value: .number(value as NSNumber), forKey: key.stringValue)
+    }
+    
+    mutating func encode(_ value: UInt64, forKey key: Key) throws {
+        future.value!.objectSet(value: .number(value as NSNumber), forKey: key.stringValue)
+    }
+    
+    mutating func encode<T>(_ value: T, forKey key: Key) throws where T : Encodable {
+        let encoder = FragmentEncoder(codingPath: codingPath + [key])
+        try value.encode(to: encoder)
+        future.value!.objectSet(value: encoder.future.value!, forKey: key.stringValue)
+    }
+    
+    mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: Key) -> KeyedEncodingContainer<NestedKey> where NestedKey : CodingKey {
+        let object = JSONValue.emptyObject()
+        future.value!.objectSet(value: object, forKey: key.stringValue)
+        return KeyedEncodingContainer(KeyedFragmentEncodingContainer<NestedKey>(future: JSONFuture(value: object), codingPath: codingPath + [key]))
+    }
+    
+    mutating func nestedUnkeyedContainer(forKey key: Key) -> UnkeyedEncodingContainer {
+        let array = JSONValue.emptyArray()
+        future.value!.objectSet(value: array, forKey: key.stringValue)
+        return UnkeyedFragmentEncodingContainer(future: JSONFuture(value: array), codingPath: codingPath + [key])
+    }
+    
+    mutating func superEncoder() -> Encoder {
+        fatalError()
+    }
+    
+    mutating func superEncoder(forKey key: Key) -> Encoder {
+        fatalError()
+    }
+    
+}
+
+struct UnkeyedFragmentEncodingContainer: UnkeyedEncodingContainer {
+    let future: JSONFuture
+    let codingPath: [CodingKey]
+    
+    var count: Int {
+        future.value!.arrayCount()
+    }
+    
+    init(future: JSONFuture, codingPath: [CodingKey]) {
+        self.future = future
+        self.codingPath = codingPath
+        future.value = .emptyArray()
+    }
+    
+    mutating func encodeNil() throws {
+        future.value!.arrayAppend(value: .null())
+    }
+    
+    mutating func encode(_ value: String) throws {
+        future.value!.arrayAppend(value: .string(value))
+    }
+    
+    mutating func encode(_ value: Bool) throws {
+        future.value!.arrayAppend(value: .number(value as NSNumber))
+    }
+    
+    mutating func encode(_ value: Double) throws {
+        future.value!.arrayAppend(value: .number(value as NSNumber))
+    }
+    
+    mutating func encode(_ value: Float) throws {
+        future.value!.arrayAppend(value: .number(value as NSNumber))
+    }
+    
+    mutating func encode(_ value: Int) throws {
+        future.value!.arrayAppend(value: .number(value as NSNumber))
+    }
+    
+    mutating func encode(_ value: Int8) throws {
+        future.value!.arrayAppend(value: .number(value as NSNumber))
+    }
+    
+    mutating func encode(_ value: Int16) throws {
+        future.value!.arrayAppend(value: .number(value as NSNumber))
+    }
+    
+    mutating func encode(_ value: Int32) throws {
+        future.value!.arrayAppend(value: .number(value as NSNumber))
+    }
+    
+    mutating func encode(_ value: Int64) throws {
+        future.value!.arrayAppend(value: .number(value as NSNumber))
+    }
+    
+    mutating func encode(_ value: UInt) throws {
+        future.value!.arrayAppend(value: .number(value as NSNumber))
+    }
+    
+    mutating func encode(_ value: UInt8) throws {
+        future.value!.arrayAppend(value: .number(value as NSNumber))
+    }
+    
+    mutating func encode(_ value: UInt16) throws {
+        future.value!.arrayAppend(value: .number(value as NSNumber))
+    }
+    
+    mutating func encode(_ value: UInt32) throws {
+        future.value!.arrayAppend(value: .number(value as NSNumber))
+    }
+    
+    mutating func encode(_ value: UInt64) throws {
+        future.value!.arrayAppend(value: .number(value as NSNumber))
+    }
+    
+    mutating func encode<T>(_ value: T) throws where T : Encodable {
+        let encoder = FragmentEncoder(codingPath: codingPath + [IntKey(intValue: count)!])
+        try value.encode(to: encoder)
+        future.value!.arrayAppend(value: encoder.future.value!)
+    }
+    
+    mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type) -> KeyedEncodingContainer<NestedKey> where NestedKey : CodingKey {
+        let object = JSONValue.emptyObject()
+        future.value!.arrayAppend(value: object)
+        return KeyedEncodingContainer(KeyedFragmentEncodingContainer<NestedKey>(future: JSONFuture(value: object), codingPath: codingPath + [IntKey(intValue: count - 1)!]))
+    }
+    
+    mutating func nestedUnkeyedContainer() -> UnkeyedEncodingContainer {
+        let array = JSONValue.emptyArray()
+        future.value!.arrayAppend(value: array)
+        return UnkeyedFragmentEncodingContainer(future: JSONFuture(value: array), codingPath: codingPath + [IntKey(intValue: count - 1)!])
+    }
+    
+    func superEncoder() -> Encoder {
+        fatalError()
+    }
+    
+}
+
+struct SingleValueFragmentEncodingContainer: SingleValueEncodingContainer {
+    let future: JSONFuture
+    let codingPath: [CodingKey]
+    
+    mutating func encodeNil() throws {
+        future.value = .null()
+    }
+    
+    mutating func encode(_ value: String) throws {
+        future.value = .string(value)
+    }
+    
+    mutating func encode(_ value: Bool) throws {
+        future.value = .number(value as NSNumber)
+    }
+    
+    mutating func encode(_ value: Double) throws {
+        future.value = .number(value as NSNumber)
+    }
+    
+    mutating func encode(_ value: Float) throws {
+        future.value = .number(value as NSNumber)
+    }
+    
+    mutating func encode(_ value: Int) throws {
+        future.value = .number(value as NSNumber)
+    }
+    
+    mutating func encode(_ value: Int8) throws {
+        future.value = .number(value as NSNumber)
+    }
+    
+    mutating func encode(_ value: Int16) throws {
+        future.value = .number(value as NSNumber)
+    }
+    
+    mutating func encode(_ value: Int32) throws {
+        future.value = .number(value as NSNumber)
+    }
+    
+    mutating func encode(_ value: Int64) throws {
+        future.value = .number(value as NSNumber)
+    }
+    
+    mutating func encode(_ value: UInt) throws {
+        future.value = .number(value as NSNumber)
+    }
+    
+    mutating func encode(_ value: UInt8) throws {
+        future.value = .number(value as NSNumber)
+    }
+    
+    mutating func encode(_ value: UInt16) throws {
+        future.value = .number(value as NSNumber)
+    }
+    
+    mutating func encode(_ value: UInt32) throws {
+        future.value = .number(value as NSNumber)
+    }
+    
+    mutating func encode(_ value: UInt64) throws {
+        future.value = .number(value as NSNumber)
+    }
+    
+    mutating func encode<T>(_ value: T) throws where T : Encodable {
+        let encoder = FragmentEncoder(codingPath: codingPath)
+        try value.encode(to: encoder)
+        future.value = encoder.future.value!
+    }
+}

--- a/Sources/LiveViewNative/LiveViewNative.docc/LiveViewNative.md
+++ b/Sources/LiveViewNative/LiveViewNative.docc/LiveViewNative.md
@@ -13,8 +13,9 @@
 - <doc:YourFirstApp>
 - <doc:GettingStarted>
 - ``LiveView``
+- ``LiveSessionCoordinator``
+- ``LiveSessionConfiguration``
 - ``LiveViewCoordinator``
-- ``LiveViewConfiguration``
 
 ### Building a Live View Template
 

--- a/Sources/LiveViewNative/NavStackEntryView.swift
+++ b/Sources/LiveViewNative/NavStackEntryView.swift
@@ -11,7 +11,7 @@ import LiveViewNativeCore
 struct NavStackEntryView<R: CustomRegistry>: View {
     private let entry: LiveNavigationEntry<R>
     @ObservedObject private var coordinator: LiveViewCoordinator<R>
-    @StateObject private var liveViewModel = LiveViewModel<R>()
+    @StateObject private var liveViewModel = LiveViewModel()
     
     init(_ entry: LiveNavigationEntry<R>) {
         self.entry = entry
@@ -35,6 +35,15 @@ struct NavStackEntryView<R: CustomRegistry>: View {
                 if let doc = newDocument {
                     // todo: doing this every time the DOM changes is probably not efficient
                     liveViewModel.updateForms(nodes: doc[doc.root()].depthFirstChildren())
+                }
+            }
+            .onReceive(coordinator.receiveEvent("_live_bindings"), perform: liveViewModel.updateBindings)
+            .onReceive(liveViewModel.bindingUpdatedByClient) { (name, value) in
+                // todo: consider grouping these into a single even per runloop iteration?
+                Task {
+                    try? await coordinator.pushEvent(type: "_live_bindings", event: name, value: [
+                        "value": value
+                    ])
                 }
             }
     }

--- a/Sources/LiveViewNative/NavStackEntryView.swift
+++ b/Sources/LiveViewNative/NavStackEntryView.swift
@@ -38,12 +38,12 @@ struct NavStackEntryView<R: CustomRegistry>: View {
                 }
             }
             .onReceive(coordinator.receiveEvent("_live_bindings"), perform: liveViewModel.updateBindings)
-            .onReceive(liveViewModel.bindingUpdatedByClient) { (name, value) in
-                // todo: consider grouping these into a single even per runloop iteration?
+            .onReceive(
+                liveViewModel.bindingUpdatedByClient
+                    .collect(.byTime(RunLoop.main, RunLoop.main.minimumTolerance))
+            ) { updates in
                 Task {
-                    try? await coordinator.pushEvent(type: "_live_bindings", event: name, value: [
-                        "value": value
-                    ])
+                    try? await coordinator.pushEvent(type: "_live_bindings", event: "_live_bindings", value: Dictionary(updates, uniquingKeysWith: { cur, new in new }))
                 }
             }
     }

--- a/Sources/LiveViewNative/Property Wrappers/FormState.swift
+++ b/Sources/LiveViewNative/Property Wrappers/FormState.swift
@@ -59,6 +59,7 @@ public struct FormState<Value: FormValue> {
     // this is non-nil iff data.mode == .local
     @State private var localValue: Value?
     @StateObject private var data = FormStateData<Value>()
+    // non-nil iff data.mode == .bound
     @LiveBinding(attribute: "value-binding") private var boundValue: Value
     
     @ObservedElement private var element: ElementNode

--- a/Sources/LiveViewNative/Property Wrappers/LiveBinding.swift
+++ b/Sources/LiveViewNative/Property Wrappers/LiveBinding.swift
@@ -1,0 +1,153 @@
+//
+//  LiveBinding.swift
+//  LiveViewNative
+//
+//  Created by Shadowfacts on 1/25/23.
+//
+
+import SwiftUI
+import LiveViewNativeCore
+import Combine
+
+/// Live bindings provide a mechanism for sharing state between the server and client in a way that can be updated by either.
+///
+/// Updates to the value from the client-side will automatically send an event to the server to update its stored value.
+/// Likewise, whenever the value is updated on the server, an event will be sent to the client which will trigger the `@LiveBinding` to update and the SwiftUI view that contains it (as well as any that use the ``projectedValue`` binding) to re-render.
+///
+/// ### Binding Names
+/// The name of a live binding is not defined directly by the client.
+/// Instead, it always controlled by the backend, to prevent the name getting out-of-sync, especially when multiple client versions may be in use.
+/// The name of the live binding is given by the value of the attribute whose name is provided to the ``LiveBinding/init(attribute:)`` initializer.
+///
+/// ### Server Support
+/// As live bindings are two-way mechanism, they are not implemented purely on the client, but rather require server-side support.
+///
+/// The server sends an event on mount with all of the binding values, sends an event when a binding is changed, and handles an even when a binding is changed on the client. These are all provided by the [`live_view_native_swift_ui`](https://github.com/liveviewnative/live_view_native_swift_ui) Elixir package.
+///
+/// The `bindings` macro takes a keyword list of bindings and their initial values and automatically generates all the necessary supporting code.
+/// The Elixir value used for the initial binding value must be serializable as JSON.
+///
+/// ```elixir
+/// defmodule AppWeb.TestLive do
+///     use AppWeb, :live_view
+///     use LiveViewNativeSwiftUi.Bindings
+///
+///     bindings(toggle_binding: false)
+/// end
+/// ```
+///
+/// Then, in the template, the same name is given as the value of a binding attribute:
+///
+/// ```html
+/// <my-toggle is-on="toggle_binding" />
+/// ```
+///
+/// ### Client Usage
+/// To use this property wrapper, the wrapped type must impelement the `Codable` protocol to define how values are serialized over the network.
+///
+/// ```swift
+/// struct MyToggle: View {
+///     @LiveBinding(attribute: "is-on") private var isOn: Bool
+///
+///     var body: some View {
+///         Toggle(isOn: $isOn) {
+///             Text("My Toggle")
+///         }
+///     }
+/// }
+/// ```
+@propertyWrapper
+public struct LiveBinding<Value: Codable> {
+    private let attributeName: AttributeName
+    @StateObject private var data = Data()
+    
+    @ObservedElement private var element
+    @Environment(\.coordinatorEnvironment) private var coordinator
+    @EnvironmentObject private var liveViewModel: LiveViewModel
+    
+    private var bindingName: String {
+        guard let name = element.attributeValue(for: attributeName) else {
+            fatalError("@LiveBinding missing binding name for \(attributeName)")
+        }
+        return name
+    }
+    
+    /// Creates a `LiveBinding` property wrapper that uses the binding in the given attribute.
+    ///
+    /// See ``LiveBinding`` for a discussion of how the underlying binding name is determined.
+    public init(attribute: AttributeName) {
+        self.attributeName = attribute
+    }
+    
+    /// The value of the binding.
+    ///
+    /// Setting this property will send an event to the server to update its value as well.
+    public var wrappedValue: Value {
+        get {
+            return data.getValue(from: liveViewModel, bindingName: bindingName)
+        }
+        nonmutating set {
+            // update the local value
+            data.mode = .local(newValue)
+            // update the view model, which will send an update to the backend
+            let encoder = FragmentEncoder()
+            // todo: if encoding fails, what should happen?
+            try! newValue.encode(to: encoder)
+            // todo: force unwrap here forbids null binding values
+            liveViewModel.setBinding(bindingName, to: encoder.unwrap()!)
+        }
+    }
+    
+    /// A SwiftUI `Binding` that provides read and write access to the underlying data.
+    ///
+    /// Access this binding with the dollar sign prefix. If a property is declared as `@LiveBinding(name: "value") var value`, then the projected value binding can be access as `$value`.
+    public var projectedValue: Binding<Value> {
+        Binding {
+            return self.wrappedValue
+        } set: { newValue in
+            self.wrappedValue = newValue
+        }
+    }
+}
+
+extension LiveBinding: DynamicProperty {
+    public func update() {
+        // don't need to do anything, just need to conform to DynamicProperty to make sure our @StateObject gets installed
+    }
+}
+
+extension LiveBinding {
+    class Data: ObservableObject {
+        var mode: Mode = .uninitialized
+        private var cancellable: AnyCancellable?
+        
+        func getValue(from liveViewModel: LiveViewModel, bindingName: String) -> Value {
+            switch mode {
+            case .uninitialized:
+                cancellable = liveViewModel.bindingUpdatedByServer
+                    .filter { $0.0 == bindingName }
+                    .sink { [unowned self] _ in
+                        self.mode = .needsUpdateFromViewModel
+                        self.objectWillChange.send()
+                    }
+                fallthrough
+            case .needsUpdateFromViewModel:
+                guard let defaultPayload = liveViewModel.bindingValues[bindingName] else {
+                    fatalError("@LiveBinding for \(bindingName) must have value sent before use")
+                }
+                // todo: if decoding fails, what should happen?
+                let value = try! Value(from: FragmentDecoder(data: defaultPayload))
+                mode = .local(value)
+                return value
+            case .local(let value):
+                return value
+            }
+        }
+        
+        enum Mode {
+            case uninitialized
+            case needsUpdateFromViewModel
+            case local(Value)
+        }
+    }
+}

--- a/Sources/LiveViewNative/Property Wrappers/LiveBinding.swift
+++ b/Sources/LiveViewNative/Property Wrappers/LiveBinding.swift
@@ -108,6 +108,15 @@ public struct LiveBinding<Value: Codable>: Decodable {
         }
     }
     
+    var isBound: Bool {
+        switch bindingNameSource {
+        case .fixed(_):
+            return true
+        case .attribute(let attr):
+            return element.attribute(named: attr) != nil
+        }
+    }
+    
     /// Creates a `LiveBinding` property wrapper that uses the binding in the given attribute.
     ///
     /// This initializer should be used when the live binding is used as part of an element.
@@ -140,8 +149,7 @@ public struct LiveBinding<Value: Codable>: Decodable {
             let encoder = FragmentEncoder()
             // todo: if encoding fails, what should happen?
             try! newValue.encode(to: encoder)
-            // todo: force unwrap here forbids null binding values
-            liveViewModel.setBinding(bindingName, to: encoder.unwrap()!)
+            liveViewModel.setBinding(bindingName, to: encoder.unwrap() as Any)
         }
     }
     

--- a/Sources/LiveViewNative/Property Wrappers/ObservedElement.swift
+++ b/Sources/LiveViewNative/Property Wrappers/ObservedElement.swift
@@ -11,7 +11,10 @@ import Combine
 
 /// A property wrapper that observes changes to an element in the coordinator's document.
 ///
-/// When an element is changed as a result of a LiveView update, the coordinator will notify all changed elements.
+/// The element that is observed is the nearest parent from the view in which this property wrapper is used.
+/// So, if an element `<outer>` maps to a view `Outer` which contains another view `Inner` that uses this property wrapper, the observed element will be the `<outer>`.
+///
+/// When an element is changed as a result of a LiveView update, the coordinator will notify all relevant views.
 /// Any SwiftUI views using `@ObservedElement` will be updated automatically when the observed element changes.
 ///
 /// The following changes are observed:

--- a/Sources/LiveViewNative/ViewModel.swift
+++ b/Sources/LiveViewNative/ViewModel.swift
@@ -180,8 +180,22 @@ public class FormModel: ObservableObject, CustomDebugStringConvertible {
     
 }
 
-/// A form value is any type that can be stored in a ``FormModel``. This protocol defines the requirements for converting to/from the serialized form data representation.
-public protocol FormValue: Equatable {
+/// A form value is any type that can be stored in a ``FormModel`` and used with ``FormState``.
+///
+/// This protocol defines the requirements for converting to/from the serialized form data representation.
+/// There are two serialized formats: form value strings and the codable representation.
+///
+/// The form value string (``formValue`` and ``init(formValue:)``) mode is used for form values that are provided in a `value` attribute on form controls or are stored in `<phx-form>` elements.
+///
+/// The `Codable` mode is used when a live binding is used with a form control.
+/// See ``FormState`` for more information about how form values and live bindings interact.
+///
+/// A number of out-of-the-box `FormValue` implementations are provided:
+/// 1. `Optional`, when the `Wrapped` type itself conforms to `FormValue`
+/// 2. `String`
+/// 3. `Bool`
+/// 4. `Double`
+public protocol FormValue: Equatable, Codable {
     /// Converts the value from this type to the string representation.
     var formValue: String { get }
     

--- a/Sources/LiveViewNative/Views/PhxForm.swift
+++ b/Sources/LiveViewNative/Views/PhxForm.swift
@@ -11,7 +11,7 @@ struct PhxForm<R: CustomRegistry>: View {
     @ObservedElement private var element: ElementNode
     private let context: LiveContext<R>
     
-    @EnvironmentObject private var liveViewModel: LiveViewModel<R>
+    @EnvironmentObject private var liveViewModel: LiveViewModel
     
     private var model: FormModel {
         guard let id = element.attributeValue(for: "id") else {

--- a/Tests/LiveViewNativeTests/FragmentEncoderTests.swift
+++ b/Tests/LiveViewNativeTests/FragmentEncoderTests.swift
@@ -1,0 +1,47 @@
+//
+//  FragmentEncoderTests.swift
+//  
+//
+//  Created by Shadowfacts on 1/27/23.
+//
+
+import XCTest
+@testable import LiveViewNative
+
+final class FragmentEncoderTests: XCTestCase {
+
+    func testFragmentEncoder() throws {
+        struct Test: Encodable, Equatable {
+            let b: Bool
+            let s: String
+            let d: Double
+            let f: Float
+            let i: Int
+            let o: Nested
+            let a: [Nested]
+        }
+        struct Nested: Encodable, Equatable {
+            let s: String
+        }
+        let expected: [String: Any?] = [
+            "b": false,
+            "s": "hello",
+            "d": 3.14,
+            "f": 1.0,
+            "i": -1,
+            "o": [
+                "s": "foo"
+            ],
+            "a": [
+                [
+                    "s": "bar"
+                ]
+            ]
+        ]
+        let test = Test(b: false, s: "hello", d: 3.14, f: 1.0, i: -1, o: Nested(s: "foo"), a: [Nested(s: "bar")])
+        let encoder = FragmentEncoder()
+        try test.encode(to: encoder)
+        XCTAssertEqual(encoder.unwrap() as! [String: Any?] as NSDictionary, expected as NSDictionary)
+    }
+    
+}


### PR DESCRIPTION
This PR adds two things:
1. A proper, public API for handling events on the client
2. The real meat and potatoes: live bindings, a mechanism for two-way client/server bindings

~~The only thing that remains before this can be merged is integrating live bindings with `@FormState`. Form state elements currently always use the `value` attribute and store data either locally or in an `<phx-form>`. Once this is implemented, if the `value-binding` attribute is present, it will establish a live binding which will be used for storage.~~

## Event Handling
Event handling uses Combine, which allows for cancelling previously created event handlers as well as easily listening for events from within the SwiftUI lifecycle (using `onReceive`).

## Live Bindings 🎉
Bindings must be declared on the server-side live view, in this example it's done like so:

```elixir
defmodule BackendtestWeb.TestLive do
  use BackendtestWeb, :live_view
  use BackendtestWeb.Bindings

  bindings(my_bool: false)

  def handle_event("toggle", _, socket) do
    {:noreply, set_my_bool(socket, !get_my_bool(socket))}
  end
end
```

And in the template it's used as:
```html
<text>Hello</text>
<text>my_bool: <%= @my_bool %></text>
<bound-toggle value="my_bool" />
<button phx-click="toggle">
	<text>Toggle from backend</text>
</button>
```

And the `bindings` macro, which will be part of the `live_view_native_swift_ui` package:
```elixir
defmacro bindings(names_and_defaults) do
  quote bind_quoted: [names_and_defaults: names_and_defaults] do
    on_mount {__MODULE__, :_set_binding_defaults}

    def on_mount(:_set_binding_defaults, _params, _session, socket) do
      {
        :cont,
        socket
        |> assign(unquote(names_and_defaults))
        |> push_event("_live_bindings", Map.new(unquote(names_and_defaults)))
      }
    end

    Enum.each(names_and_defaults, fn {name, _default} ->
      def unquote(:"get_#{name}")(socket) do
        socket.assigns[unquote(name)]
      end

      def unquote(:"set_#{name}")(socket, value) do
        socket
        |> assign(unquote(name), value)
        # todo: it would be nice if there were a hook that let us coalesce multiple changes in a single callback into one event
        |> push_event("_live_bindings", %{unquote(name) => value})
      end

      def handle_event(unquote(to_string(name)), %{"value" => value}, socket) do
        {:noreply, assign(socket, unquote(name), value)}
      end
    end)
  end
end
```

And finally from SwiftUI, the binding can be used like so:
```swift
struct BoundToggle: View {
    @LiveBinding(attribute: "value") private var value: Bool
    
    var body: some View {
        SwiftUI.Toggle(isOn: $value) {
            SwiftUI.Text("Bound toggle")
        }
    }
}
```

The screen recording shows both client -> server updates (when the toggle switch is clicked, and the text updates) and server -> client updates (when the button is clicked and the toggle switch updates) working:

https://user-images.githubusercontent.com/7091588/216186677-338e1f19-ad20-4f86-881f-586f7f17fa2b.mov

### From View Modifiers
A live binding can also be used on a view modifier. The property wrapper conforms to `Decodable`, so it can be initialized in the modifier's decode implementation.

### Form State
All `@FormState` elements now also have an optional `value-binding` attribute which specifies the name of a live binding to use in place of the local or `<phx-form>` storage.