### PR TITLE
Add Section

### DIFF
--- a/Sources/LiveViewNative/BuiltinRegistry.swift
+++ b/Sources/LiveViewNative/BuiltinRegistry.swift
@@ -88,6 +88,8 @@ struct BuiltinRegistry: BuiltinRegistryProtocol {
             Stepper(element: element, context: context)
         case "form":
             Form(context: context)
+        case "section":
+            Section(element: element, context: context)
         case "phx-form":
             PhxForm<R>(element: element, context: context)
         case "phx-submit-button":

--- a/Sources/LiveViewNative/Utils/DOM.swift
+++ b/Sources/LiveViewNative/Utils/DOM.swift
@@ -64,6 +64,17 @@ public struct ElementNode {
         attribute(named: name)?.value
     }
     
+    /// Checks for a [boolean attribute](https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#boolean-attributes).
+    ///
+    /// If the attribute is present, the value is `true`.
+    ///
+    ///
+    /// > The strings `"true"`/`"false"` are ignored, and only the presence of the attribute is considered.
+    /// > A value of `"false"` would still return `true`.
+    public func attributeBoolean(for name: AttributeName) -> Bool {
+        attribute(named: name) != nil
+    }
+    
     /// The text of this element.
     ///
     /// The returned string only incorporates the direct text node children, not any text nodes within nested elements.

--- a/Sources/LiveViewNative/Views/Layout Containers/Collection Containers/Section.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Collection Containers/Section.swift
@@ -18,10 +18,18 @@ struct Section<R: CustomRegistry>: View {
     public var body: some View {
         #if os(macOS)
         self.section
-            .collapsible(element.attributeValue(for: "collapsible").flatMap(Bool.init(_:)) ?? false)
+            .collapsible(isCollapsible)
         #else
         self.section
         #endif
+    }
+    
+    private var isCollapsible: Bool {
+        guard let collapsible = element.attribute(named: "collapsible")
+        else { return false }
+        guard let value = collapsible.value
+        else { return true }
+        return Bool(value) ?? false
     }
     
     private var section: SwiftUI.Section<some View, some View, some View> {

--- a/Sources/LiveViewNative/Views/Layout Containers/Collection Containers/Section.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Collection Containers/Section.swift
@@ -16,23 +16,6 @@ struct Section<R: CustomRegistry>: View {
     }
     
     public var body: some View {
-        #if os(macOS)
-        self.section
-            .collapsible(isCollapsible)
-        #else
-        self.section
-        #endif
-    }
-    
-    private var isCollapsible: Bool {
-        guard let collapsible = element.attribute(named: "collapsible")
-        else { return false }
-        guard let value = collapsible.value
-        else { return true }
-        return Bool(value) ?? false
-    }
-    
-    private var section: SwiftUI.Section<some View, some View, some View> {
         SwiftUI.Section {
             context.buildChildren(of: element, withTagName: "content", namespace: "section", includeDefaultSlot: true)
         } header: {
@@ -40,5 +23,8 @@ struct Section<R: CustomRegistry>: View {
         } footer: {
             context.buildChildren(of: element, withTagName: "footer", namespace: "section")
         }
+        #if os(macOS)
+            .collapsible(element.attributeBoolean(for: "collapsible"))
+        #endif
     }
 }

--- a/Sources/LiveViewNative/Views/Layout Containers/Collection Containers/Section.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Collection Containers/Section.swift
@@ -1,0 +1,36 @@
+//
+//  Section.swift
+//  
+//
+//  Created by Carson Katri on 2/2/23.
+//
+
+import SwiftUI
+
+struct Section<R: CustomRegistry>: View {
+    @ObservedElement private var element: ElementNode
+    private let context: LiveContext<R>
+    
+    init(element: ElementNode, context: LiveContext<R>) {
+        self.context = context
+    }
+    
+    public var body: some View {
+        #if os(macOS)
+        self.section
+            .collapsible(element.attributeValue(for: "collapsible").flatMap(Bool.init(_:)) ?? false)
+        #else
+        self.section
+        #endif
+    }
+    
+    private var section: SwiftUI.Section<some View, some View, some View> {
+        SwiftUI.Section {
+            context.buildChildren(of: element, withTagName: "content", namespace: "section", includeDefaultSlot: true)
+        } header: {
+            context.buildChildren(of: element, withTagName: "header", namespace: "section")
+        } footer: {
+            context.buildChildren(of: element, withTagName: "footer", namespace: "section")
+        }
+    }
+}

--- a/Tests/RenderingTests/CollectionContainerTests.swift
+++ b/Tests/RenderingTests/CollectionContainerTests.swift
@@ -11,6 +11,8 @@ import SwiftUI
 
 @MainActor
 final class CollectionContainerTests: XCTestCase {
+    // MARK: List
+    
     func testList() throws {
         try assertMatch(
             #"""
@@ -90,5 +92,44 @@ final class CollectionContainerTests: XCTestCase {
             list.listStyle(.grouped)
         }
 #endif
+    }
+    
+    // MARK: Section
+    
+    func testSection() throws {
+        try assertMatch(
+            #"""
+            <section>
+                <section:header>Header</section:header>
+                <section:content>Content</section:content>
+                <section:footer>Footer</section:footer>
+            </section>
+            """#
+        ) {
+            Section {
+                Text("Content")
+            } header: {
+                Text("Header")
+            } footer: {
+                Text("Footer")
+            }
+        }
+        try assertMatch(
+            #"""
+            <section>
+                <section:header>Header</section:header>
+                Content
+                <section:footer>Footer</section:footer>
+            </section>
+            """#
+        ) {
+            Section {
+                Text("Content")
+            } header: {
+                Text("Header")
+            } footer: {
+                Text("Footer")
+            }
+        }
     }
 }


### PR DESCRIPTION
Closes #111 

```html
<section>
  <:header>5 Items</:header>
  <:content>
    <%= for item <- 1..5 do %>
      <text><%= item %></text>
    <% end %>
  </:content>
  <:footer>Above are some important items, in the range 1-5.</:footer>
</section>
```
The default slot can also be used for the content:
```html
<section>
  <:header>5 Items</:header>
  <%= for item <- 1..5 do %>
    <text><%= item %></text>
  <% end %>
  <:footer>Above are some important items, in the range 1-5.</:footer>
</section>
```

![Simulator Screen Shot - iPhone 14 Pro - 2023-02-02 at 10 41 21](https://user-images.githubusercontent.com/13581484/216371440-d6767eef-3680-4e10-a489-96de4ebcc696.png)

### Collapsible
On macOS, with the `sidebar` list style sections can be marked `collapsible`.

On iOS, sidebar list sections are always collapsible and the modifier is unavailable.

```html
<section collapsible="true">
  ...
</section>
<section> ... </section>
```

https://user-images.githubusercontent.com/13581484/216371451-70a03e8a-ea01-4e07-a762-9f98bf79fefc.mov

