### PR TITLE
Add Group

### DIFF
--- a/Sources/LiveViewNative/BuiltinRegistry.swift
+++ b/Sources/LiveViewNative/BuiltinRegistry.swift
@@ -94,6 +94,8 @@ struct BuiltinRegistry: BuiltinRegistryProtocol {
         case "text-editor":
             TextEditor(element: element, context: context)
 #endif
+        case "group":
+            Group(element: element, context: context)
             
         case "phx-form":
             PhxForm<R>(element: element, context: context)

--- a/Sources/LiveViewNative/LiveView.swift
+++ b/Sources/LiveViewNative/LiveView.swift
@@ -102,7 +102,7 @@ public struct LiveView<R: CustomRegistry>: View {
                 }
                 session.navigationPath = result
             }) {
-                Group {
+                SwiftUI.Group {
                     if let entry = session.navigationPath.first {
                         NavStackEntryView(entry)
                     }

--- a/Sources/LiveViewNative/NavStackEntryView.swift
+++ b/Sources/LiveViewNative/NavStackEntryView.swift
@@ -64,7 +64,7 @@ struct NavStackEntryView<R: CustomRegistry>: View {
                     fatalError("State is `.connected`, but no `Document` was found.")
                 }
             default:
-                let content = Group {
+                let content = SwiftUI.Group {
                     if R.LoadingView.self == Never.self {
                         switch coordinator.state {
                         case .connected:

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Indicators/Gauge.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Indicators/Gauge.swift
@@ -17,7 +17,7 @@ struct Gauge<R: CustomRegistry>: View {
     }
     
     public var body: some View {
-        Group {
+        SwiftUI.Group {
             if context.hasChild(of: element, withTagName: "current-value-label", namespace: "gauge") ||
                context.hasChild(of: element, withTagName: "minimum-value-label", namespace: "gauge") ||
                context.hasChild(of: element, withTagName: "maximum-value-label", namespace: "gauge")

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Indicators/ProgressView.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Indicators/ProgressView.swift
@@ -16,7 +16,7 @@ struct ProgressView<R: CustomRegistry>: View {
     }
     
     public var body: some View {
-        Group {
+        SwiftUI.Group {
             if let timerIntervalStart = element.attributeValue(for: "timer-interval-start").flatMap({ try? ElixirDateParseStrategy().parse($0) }),
                let timerIntervalEnd = element.attributeValue(for: "timer-interval-end").flatMap({ try? ElixirDateParseStrategy().parse($0) })
             {

--- a/Sources/LiveViewNative/Views/Layout Containers/Groups/Group.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Groups/Group.swift
@@ -1,0 +1,23 @@
+//
+//  Group.swift
+//  
+//
+//  Created by Carson Katri on 2/9/23.
+//
+
+import SwiftUI
+
+struct Group<R: CustomRegistry>: View {
+    @ObservedElement private var element: ElementNode
+    private let context: LiveContext<R>
+    
+    init(element: ElementNode, context: LiveContext<R>) {
+        self.context = context
+    }
+
+    public var body: some View {
+        SwiftUI.Group {
+            context.buildChildren(of: element)
+        }
+    }
+}


### PR DESCRIPTION
Closes #117 

The main utility of the `Group` view for LVN is applying the same modifier stack to multiple Views:

```html
<group modifiers={@native |> padding(all: 16)}>
  <text>LiveView Native group</text>
  <text>it pairs together the views</text>
  <text>to modify them</text>
</group>
```

<img src="https://user-images.githubusercontent.com/13581484/217843679-0cfba938-d2cb-4d8c-a809-0eacdbd1e402.png" width="300px" />

Without `Group` the modifiers would need to be repeated:
```html
<text modifiers={@native |> padding(all: 16)}>LiveView Native group</text>
<text modifiers={@native |> padding(all: 16)}>it pairs together the views</text>
<text modifiers={@native |> padding(all: 16)}>to modify them</text>
```