### PR TITLE
Add GroupBox

### DIFF
--- a/Sources/LiveViewNative/BuiltinRegistry.swift
+++ b/Sources/LiveViewNative/BuiltinRegistry.swift
@@ -93,6 +93,8 @@ struct BuiltinRegistry: BuiltinRegistryProtocol {
 #if os(iOS) || os(macOS)
         case "text-editor":
             TextEditor(element: element, context: context)
+        case "group-box":
+            GroupBox(element: element, context: context)
 #endif
             
         case "phx-form":

--- a/Sources/LiveViewNative/Views/Layout Containers/Groups/GroupBox.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Groups/GroupBox.swift
@@ -1,0 +1,50 @@
+//
+//  GroupBox.swift
+//
+//
+//  Created by Carson Katri on 2/9/23.
+//
+
+#if os(iOS) || os(macOS)
+import SwiftUI
+
+struct GroupBox<R: CustomRegistry>: View {
+    @ObservedElement private var element: ElementNode
+    private let context: LiveContext<R>
+
+    init(element: ElementNode, context: LiveContext<R>) {
+        self.context = context
+    }
+
+    public var body: some View {
+        SwiftUI.Group {
+            if let title = element.attributeValue(for: "title") {
+                SwiftUI.GroupBox(title) {
+                    context.buildChildren(of: element)
+                }
+            } else {
+                SwiftUI.GroupBox {
+                    context.buildChildren(of: element, withTagName: "content", namespace: "group-box", includeDefaultSlot: true)
+                } label: {
+                    context.buildChildren(of: element, withTagName: "label", namespace: "group-box")
+                }
+            }
+        }
+        .applyGroupBoxStyle(element.attributeValue(for: "group-box-style").flatMap(GroupBoxStyle.init) ?? .automatic)
+    }
+}
+
+fileprivate enum GroupBoxStyle: String {
+    case automatic
+}
+
+fileprivate extension View {
+    @ViewBuilder
+    func applyGroupBoxStyle(_ style: GroupBoxStyle) -> some View {
+        switch style {
+        case .automatic:
+            self.groupBoxStyle(.automatic)
+        }
+    }
+}
+#endif

--- a/Sources/LiveViewNative/Views/Layout Containers/Scroll Views/ScrollView.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Scroll Views/ScrollView.swift
@@ -16,7 +16,7 @@ struct ScrollView<R: CustomRegistry>: View {
     }
     
     public var body: some View {
-        SwiftUI.ScrollView(axes, showsIndicators: showsIndicators) {
+        SwiftUI.ScrollView(axes, showsIndicators: element.attributeBoolean(for: "shows-indicators")) {
             context.buildChildren(of: element)
         }
     }
@@ -31,13 +31,4 @@ struct ScrollView<R: CustomRegistry>: View {
             return .vertical
         }
     }
-    
-    private var showsIndicators: Bool {
-        if let attr = element.attributeValue(for: "shows-indicators") {
-            return attr == "true"
-        } else {
-            return true
-        }
-    }
-    
 }


### PR DESCRIPTION
Closes #118 

```html
<group-box>
  <group-box:label>
    <label system-image="building.columns">End-User Agreement</label>
  </group-box:label>
  <group-box:content>
    <scroll-view axes="vertical" shows-indicators modifiers={@native |> frame(height: 100)}>
      <text font="footnote">
        <%= @agreement_text %>
      </text>
    </scroll-view>
    <toggle value-binding="user_agreed">I agree to the above terms</toggle>
  </group-box:content>
</group-box>
```

<img src="https://user-images.githubusercontent.com/13581484/217847615-f9fb01f0-cd30-46d8-bedc-1280b21b9358.png" width="300" />

I also updated `ScrollView` to use the `attributeBoolean(for:)` helper for the scroll indicators.
