### PR TITLE
Add ControlGroup

### DIFF
--- a/Sources/LiveViewNative/BuiltinRegistry.swift
+++ b/Sources/LiveViewNative/BuiltinRegistry.swift
@@ -95,6 +95,8 @@ struct BuiltinRegistry: BuiltinRegistryProtocol {
             TextEditor(element: element, context: context)
         case "group-box":
             GroupBox(element: element, context: context)
+        case "control-group":
+            ControlGroup(element: element, context: context)
 #endif
             
         case "phx-form":

--- a/Sources/LiveViewNative/Views/Layout Containers/Groups/ControlGroup.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Groups/ControlGroup.swift
@@ -1,0 +1,47 @@
+//
+//  ControlGroup.swift
+//
+//
+//  Created by Carson Katri on 2/9/23.
+//
+
+#if os(iOS) || os(macOS)
+import SwiftUI
+
+struct ControlGroup<R: CustomRegistry>: View {
+    @ObservedElement private var element: ElementNode
+    private let context: LiveContext<R>
+
+    init(element: ElementNode, context: LiveContext<R>) {
+        self.context = context
+    }
+
+    public var body: some View {
+        SwiftUI.Group {
+            SwiftUI.ControlGroup {
+                context.buildChildren(of: element, withTagName: "content", namespace: "control-group", includeDefaultSlot: true)
+            } label: {
+                context.buildChildren(of: element, withTagName: "label", namespace: "control-group")
+            }
+        }
+        .applyControlGroupStyle(element.attributeValue(for: "control-group-style").flatMap(ControlGroupStyle.init) ?? .automatic)
+    }
+}
+
+fileprivate enum ControlGroupStyle: String {
+    case automatic
+    case navigation
+}
+
+fileprivate extension View {
+    @ViewBuilder
+    func applyControlGroupStyle(_ style: ControlGroupStyle) -> some View {
+        switch style {
+        case .automatic:
+            self.controlGroupStyle(.automatic)
+        case .navigation:
+            self.controlGroupStyle(.navigation)
+        }
+    }
+}
+#endif

--- a/Tests/RenderingTests/GroupTests.swift
+++ b/Tests/RenderingTests/GroupTests.swift
@@ -123,8 +123,7 @@ final class GroupTests: XCTestCase {
                 <button>Action #2</button>
                 <button>Action #3</button>
             </control-group>
-            """#,
-            lifetime: .keepAlways
+            """#
         ) {
             ControlGroup {
                 Button("Action #1") {}
@@ -140,8 +139,7 @@ final class GroupTests: XCTestCase {
                 <button>Action #2</button>
                 <button>Action #3</button>
             </control-group>
-            """#,
-            lifetime: .keepAlways
+            """#
         ) {
             ControlGroup {
                 Button("Action #1") {}

--- a/Tests/RenderingTests/GroupTests.swift
+++ b/Tests/RenderingTests/GroupTests.swift
@@ -11,9 +11,8 @@ import SwiftUI
 
 @MainActor
 final class GroupTests: XCTestCase {
-    // MARK: GroupBox
-    
 #if os(iOS) || os(macOS)
+    // MARK: GroupBox
     func testGroupBox() throws {
         try assertMatch(
             #"""
@@ -68,6 +67,88 @@ final class GroupTests: XCTestCase {
             GroupBox("Label") {
                 Text("Content")
             }
+        }
+    }
+    
+    // MARK: ControlGroup
+    
+    func testControlGroup() throws {
+        try assertMatch(
+            #"""
+            <control-group>
+                <button>Action #1</button>
+                <button>Action #2</button>
+                <button>Action #3</button>
+            </control-group>
+            """#
+        ) {
+            ControlGroup {
+                Button("Action #1") {}
+                Button("Action #2") {}
+                Button("Action #3") {}
+            }
+        }
+    }
+    
+    func testControlGroupSlots() throws {
+        try assertMatch(
+            #"""
+            <control-group>
+                <control-group:label>
+                    Label
+                </control-group:label>
+                <control-group:content>
+                    <button>Action #1</button>
+                    <button>Action #2</button>
+                    <button>Action #3</button>
+                </control-group:content>
+            </control-group>
+            """#
+        ) {
+            ControlGroup {
+                Button("Action #1") {}
+                Button("Action #2") {}
+                Button("Action #3") {}
+            } label: {
+                Text("Label")
+            }
+        }
+    }
+    
+    func testControlGroupStyles() throws {
+        try assertMatch(
+            #"""
+            <control-group control-group-style="automatic">
+                <button>Action #1</button>
+                <button>Action #2</button>
+                <button>Action #3</button>
+            </control-group>
+            """#,
+            lifetime: .keepAlways
+        ) {
+            ControlGroup {
+                Button("Action #1") {}
+                Button("Action #2") {}
+                Button("Action #3") {}
+            }
+            .controlGroupStyle(.automatic)
+        }
+        try assertMatch(
+            #"""
+            <control-group control-group-style="navigation">
+                <button>Action #1</button>
+                <button>Action #2</button>
+                <button>Action #3</button>
+            </control-group>
+            """#,
+            lifetime: .keepAlways
+        ) {
+            ControlGroup {
+                Button("Action #1") {}
+                Button("Action #2") {}
+                Button("Action #3") {}
+            }
+            .controlGroupStyle(.navigation)
         }
     }
 #endif


### PR DESCRIPTION
Closes #119 

```html
<text><%= @number %></text>
<control-group>
  <control-group:label>
    <label system-image="gear">Options</label>
  </control-group:label>
  <control-group:content>
    <%= for item <- 1..5 do %>
      <button phx-click="set_number" phx-value-number={item}>Item #<%= item %></button>
    <% end %>
  </control-group:content>
</control-group>
```

https://user-images.githubusercontent.com/13581484/217863551-9a659ceb-fe3a-4fd7-ac29-3a8f9957d4f6.mp4

This will become more useful once we have the `toolbar` modifier.