### PR TITLE
Performance improvements when handling document updates

### DIFF
--- a/Sources/LiveViewNative/LiveContext.swift
+++ b/Sources/LiveViewNative/LiveContext.swift
@@ -87,13 +87,9 @@ public struct LiveContext<R: CustomRegistry> {
                     return true
                 }
             })
-            return ForEach([(element.node.id, defaultSlotChildren)], id: \.0) { subChildren in
-                coordinator.builder.fromNodes(subChildren.1, context: self)
-            }
+            return coordinator.builder.fromNodes(defaultSlotChildren, context: self)
         } else {
-            return ForEach(namedSlotChildren.map({ ($0.id, Array($0.children())) }), id: \.0) { subChildren in
-                coordinator.builder.fromNodes(subChildren.1, context: self)
-            }
+            return coordinator.builder.fromNodes(namedSlotChildren.flatMap { $0.children() }, context: self)
         }
     }
 }

--- a/Sources/LiveViewNative/Property Wrappers/ObservedElement.swift
+++ b/Sources/LiveViewNative/Property Wrappers/ObservedElement.swift
@@ -35,7 +35,7 @@ import Combine
 /// }
 @propertyWrapper
 public struct ObservedElement {
-    @Environment(\.element) private var element: ElementNode?
+    @Environment(\.element.nodeRef) private var nodeRef: NodeRef?
     @Environment(\.coordinatorEnvironment) private var coordinator: CoordinatorEnvironment?
     @StateObject private var observer = Observer()
     
@@ -45,11 +45,11 @@ public struct ObservedElement {
     
     /// The observed element in the document, with all current data.
     public var wrappedValue: ElementNode {
-        guard let element,
+        guard let nodeRef,
               let coordinator else {
             fatalError("Cannot use @ObservedElement on view that does not have an element and coordinator in the environment")
         }
-        guard let element = coordinator.document[element.node.id].asElement() else {
+        guard let element = coordinator.document[nodeRef].asElement() else {
             preconditionFailure("@ObservedElement ref turned into a non-element node, this should not be possible")
         }
         return element
@@ -58,11 +58,11 @@ public struct ObservedElement {
 
 extension ObservedElement: DynamicProperty {
     public func update() {
-        guard let element,
+        guard let nodeRef,
               let coordinator else {
             fatalError("Cannot use @ObservedElement on view that does not have an element and coordinator in the environment")
         }
-        self.observer.update(ref: element.node.id, elementChanged: coordinator.elementChanged)
+        self.observer.update(ref: nodeRef, elementChanged: coordinator.elementChanged)
     }
 }
 
@@ -81,5 +81,11 @@ extension ObservedElement {
                     }
             }
         }
+    }
+}
+
+private extension Optional where Wrapped == ElementNode {
+    var nodeRef: NodeRef? {
+        self?.node.id
     }
 }


### PR DESCRIPTION
The first fix has to do with demangling Swift types at runtime, and seems to only be an issue in debug builds, not release, but it was untenably bad in debug. The second fixes ObservedElement views updating excessively.

Together, these bring the time for the same view update in my test from 700ms to about 60ms. In a release build, the time is about 40ms.

The test was selecting a new value in a 6-option picker that's backed by a live binding shared by 4 pickers.