### PR TITLE
List selection support

### DIFF
--- a/Sources/LiveViewNative/Views/Layout Containers/Collection Containers/List.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Collection Containers/List.swift
@@ -125,6 +125,9 @@ struct List<R: CustomRegistry>: View {
                 // todo: should this have its own type?
                 try await context.coordinator.pushEvent(type: "click", event: moveEvent, value: meta)
                 #if !os(watchOS)
+                // Workaround to fix items not following the order from the backend when changed during edit mode.
+                // Toggling edit modes forces it to follow the backend ordering.
+                // Toggles between `active`/`transient` instead of `active`/`inactive` so no transitions play.
                 if let initial = editMode?.wrappedValue {
                     editMode?.wrappedValue = initial == .transient ? .active : .transient
                     await MainActor.run {

--- a/Sources/LiveViewNative/Views/Layout Containers/Collection Containers/List.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Collection Containers/List.swift
@@ -11,16 +11,87 @@ struct List<R: CustomRegistry>: View {
     @ObservedElement private var element: ElementNode
     private let context: LiveContext<R>
     
+    /// Selection of either a single value or set of values.
+    enum Selection: Codable {
+        case single(String?)
+        case multiple(Set<String>)
+        
+        var single: String? {
+            get {
+                guard case let .single(selection) = self else { fatalError() }
+                return selection
+            }
+            set {
+                self = .single(newValue)
+            }
+        }
+        
+        var multiple: Set<String> {
+            get {
+                guard case let .multiple(selection) = self else { fatalError() }
+                return selection
+            }
+            set {
+                self = .multiple(newValue)
+            }
+        }
+        
+        init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            if container.decodeNil() {
+                self = .single(nil)
+            } else if let item = try? container.decode(String.self) {
+                self = .single(item)
+            } else {
+                self = .multiple(try container.decode(Set<String>.self))
+            }
+        }
+        
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.singleValueContainer()
+            switch self {
+            case .single(let selection):
+                try container.encode(selection)
+            case .multiple(let selection):
+                try container.encode(selection)
+            }
+        }
+    }
+    
+    @LiveBinding(attribute: "selection") private var selection = Selection.multiple([])
+    
     init(element: ElementNode, context: LiveContext<R>) {
         self.context = context
     }
     
     public var body: some View {
+        list
+            .applyListStyle(element.attributeValue(for: "list-style").flatMap(ListStyle.init) ?? .automatic)
+    }
+    
+    @ViewBuilder
+    private var list: some View {
+        #if os(watchOS)
         SwiftUI.List {
-            forEach(nodes: element.children(), context: context)
-                .onDelete(perform: onDeleteHandler)
+            content
         }
-        .applyListStyle(element.attributeValue(for: "list-style").flatMap(ListStyle.init) ?? .automatic)
+        #else
+        switch selection {
+        case .single:
+            SwiftUI.List(selection: $selection.single) {
+                content
+            }
+        case .multiple:
+            SwiftUI.List(selection: $selection.multiple) {
+                content
+            }
+        }
+        #endif
+    }
+    
+    private var content: some View {
+        forEach(nodes: element.children(), context: context)
+            .onDelete(perform: onDeleteHandler)
     }
     
     private var onDeleteHandler: ((IndexSet) -> Void)? {
@@ -54,7 +125,7 @@ fileprivate enum ListStyle: String {
 #endif
 }
 
-private extension SwiftUI.List {
+private extension View {
     @ViewBuilder
     func applyListStyle(_ style: ListStyle) -> some View {
         switch style {

--- a/Sources/LiveViewNative/Views/Layout Containers/Collection Containers/List.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Collection Containers/List.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct List<R: CustomRegistry>: View {
     @ObservedElement private var element: ElementNode
     private let context: LiveContext<R>
-    #if !os(watchOS)
+    #if os(iOS) || os(tvOS)
     @Environment(\.editMode) var editMode
     #endif
     
@@ -124,7 +124,7 @@ struct List<R: CustomRegistry>: View {
             Task { [meta] in
                 // todo: should this have its own type?
                 try await context.coordinator.pushEvent(type: "click", event: moveEvent, value: meta)
-                #if !os(watchOS)
+#if os(iOS) || os(tvOS)
                 // Workaround to fix items not following the order from the backend when changed during edit mode.
                 // Toggling edit modes forces it to follow the backend ordering.
                 // Toggles between `active`/`transient` instead of `active`/`inactive` so no transitions play.
@@ -134,7 +134,7 @@ struct List<R: CustomRegistry>: View {
                         editMode?.wrappedValue = initial
                     }
                 }
-                #endif
+#endif
             }
         }
     }


### PR DESCRIPTION
This adds support for `List.selection` using `LiveBinding`. You can specify a String value or a set of String values as the selection.

```html
<list selection="selection">
    <%= for item <- 1..10 do %>
        <text id={item |> Integer.to_string}><%= item %></text>
    <% end %>
</list>
```

```ex
defmodule ... do
  bindings(selection: ["1", "3", "5"], single_value_selection: "1", empty_single_selection: nil)

  ...
end
```


https://user-images.githubusercontent.com/13581484/218798033-150c6b1e-b9c9-4baa-9636-3a899be3153e.mp4

If you start with a value of `nil` or a single string, it will only allow one row to be selected at a time.