### PR TITLE
Add ColorPicker

### DIFF
--- a/Sources/LiveViewNative/BuiltinRegistry.swift
+++ b/Sources/LiveViewNative/BuiltinRegistry.swift
@@ -93,6 +93,8 @@ struct BuiltinRegistry: BuiltinRegistryProtocol {
 #if os(iOS) || os(macOS)
         case "text-editor":
             TextEditor(element: element, context: context)
+        case "color-picker":
+            ColorPicker(element: element, context: context)
         case "group-box":
             GroupBox(element: element, context: context)
         case "control-group":

--- a/Sources/LiveViewNative/Utils/Color.swift
+++ b/Sources/LiveViewNative/Utils/Color.swift
@@ -67,9 +67,12 @@ extension Color {
             self = .primary
         case "system-secondary":
             self = .secondary
-        // TODO: named colors from bundle?
-        default:
-            self.init(fromCSSHex: string)
+        case let string?:
+            if let hexColor = Self(fromCSSHex: string) {
+                self = hexColor
+            } else {
+                self = .init(string)
+            }
         }
     }
 }

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Pickers/ColorPicker.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Pickers/ColorPicker.swift
@@ -1,0 +1,58 @@
+//
+//  Gauge.swift
+//
+//
+//  Created by Carson Katri on 2/14/23.
+//
+
+#if os(iOS) || os(macOS)
+import SwiftUI
+
+struct ColorPicker<R: CustomRegistry>: View {
+    @ObservedElement private var element: ElementNode
+    let context: LiveContext<R>
+    
+    @LiveBinding(attribute: "selection") private var selection: CodableColor = .init(r: 0, g: 0, b: 0, a: 1)
+    
+    struct CodableColor: Codable {
+        var r: CGFloat
+        var g: CGFloat
+        var b: CGFloat
+        var a: CGFloat?
+        
+        var cgColor: CGColor {
+            get {
+                .init(red: r, green: g, blue: b, alpha: a ?? 1)
+            }
+            set {
+                guard let components = newValue.components else { return }
+                r = components[0]
+                g = components[1]
+                b = components[2]
+                if newValue.numberOfComponents >= 4 {
+                    a = components[3]
+                } else {
+                    a = nil
+                }
+            }
+        }
+    }
+    
+    init(element: ElementNode, context: LiveContext<R>) {
+        self.context = context
+    }
+    
+    public var body: some View {
+        SwiftUI.ColorPicker(
+            selection: $selection.cgColor,
+            supportsOpacity: element.attributeBoolean(for: "supports-opacity")
+        ) {
+            label
+        }
+    }
+    
+    private var label: some View {
+        context.buildChildren(of: element, withTagName: "label", namespace: "color-picker", includeDefaultSlot: true)
+    }
+}
+#endif

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Pickers/ColorPicker.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Pickers/ColorPicker.swift
@@ -1,5 +1,5 @@
 //
-//  Gauge.swift
+//  ColorPicker.swift
 //
 //
 //  Created by Carson Katri on 2/14/23.

--- a/Tests/RenderingTests/PickerTests.swift
+++ b/Tests/RenderingTests/PickerTests.swift
@@ -1,5 +1,5 @@
 //
-//  GroupTests.swift
+//  PickerTests.swift
 //
 //
 //  Created by Carson Katri on 2/14/23.

--- a/Tests/RenderingTests/PickerTests.swift
+++ b/Tests/RenderingTests/PickerTests.swift
@@ -1,0 +1,46 @@
+//
+//  GroupTests.swift
+//
+//
+//  Created by Carson Katri on 2/14/23.
+//
+
+import XCTest
+import SwiftUI
+@testable import LiveViewNative
+
+@MainActor
+final class PickerTests: XCTestCase {
+#if os(iOS) || os(macOS)
+    // MARK: ColorPicker
+    func testColorPicker() throws {
+        try assertMatch(
+            #"""
+            <color-picker>
+                <color-picker:label>Foreground</color-picker:label>
+            </color-picker>
+            """#,
+            size: .init(width: 300, height: 300)
+        ) {
+            ColorPicker(selection: .constant(.init(red: 0, green: 0, blue: 0, alpha: 1))) {
+                Text("Foreground")
+            }
+        }
+    }
+    
+    func testColorPickerDefaultSlot() throws {
+        try assertMatch(
+            #"""
+            <color-picker>
+                Background
+            </color-picker>
+            """#,
+            size: .init(width: 300, height: 300)
+        ) {
+            ColorPicker(selection: .constant(.init(red: 0, green: 0, blue: 0, alpha: 1))) {
+                Text("Background")
+            }
+        }
+    }
+#endif
+}


### PR DESCRIPTION
Closes #75. Implemented using LiveBinding, as I'm not sure if color should be a `FormValue` primitive.

```html
<z-stack alignment="bottom">
  <rectangle fill-color={TestBedWeb.IndexLive.fill_color(@color_selection)} />
  <group-box modifiers={@native |> padding(all: 16)}>
    <color-picker selection="color_selection">
      Background
    </color-picker>
  </group-box>
</z-stack>
```

```ex
defmodule ... do
  bindings(color_selection: Macro.escape(%{ "r" => 1.0, "g" => 1.0, "b" => 1.0 }))
  ...
end
```

https://user-images.githubusercontent.com/13581484/218838435-f30d1212-8842-4aa3-a363-528931840a2f.mp4

