### PR TITLE
Add Picker

### DIFF
--- a/Sources/LiveViewNative/BuiltinRegistry.swift
+++ b/Sources/LiveViewNative/BuiltinRegistry.swift
@@ -112,7 +112,8 @@ struct BuiltinRegistry: BuiltinRegistryProtocol {
             LazyVStack(element: element, context: context)
         case "lazy-h-stack", "lazy-hstack":
             LazyHStack(element: element, context: context)
-            
+        case "picker":
+            Picker(context: context)
         case "phx-form":
             PhxForm<R>(element: element, context: context)
         case "phx-submit-button":
@@ -130,6 +131,7 @@ struct BuiltinRegistry: BuiltinRegistryProtocol {
         case navigationTitle = "navigation_title"
         case padding
         case tint
+        case tag
         
         case gridCellAnchor = "grid_cell_anchor"
         case gridCellColumns = "grid_cell_columns"
@@ -152,6 +154,8 @@ struct BuiltinRegistry: BuiltinRegistryProtocol {
             try PaddingModifier(from: decoder)
         case .tint:
             try TintModifier(from: decoder)
+        case .tag:
+            try TagModifier(from: decoder)
             
         case .gridCellAnchor:
             try GridCellAnchorModifier(from: decoder)

--- a/Sources/LiveViewNative/Modifiers/TagModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/TagModifier.swift
@@ -1,0 +1,16 @@
+//
+//  TagModifier.swift
+//  LiveViewNative
+//
+//  Created by Shadowfacts on 2/10/23.
+//
+
+import SwiftUI
+
+struct TagModifier: ViewModifier, Decodable {
+    private let value: String?
+    
+    func body(content: Content) -> some View {
+        content.tag(value)
+    }
+}

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Pickers/Picker.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Pickers/Picker.swift
@@ -1,0 +1,80 @@
+//
+//  Picker.swift
+//  LiveViewNative
+//
+//  Created by Shadowfacts on 2/8/23.
+//
+
+import SwiftUI
+
+struct Picker<R: CustomRegistry>: View {
+    private let context: LiveContext<R>
+    @ObservedElement private var element
+    @FormState private var value: String?
+    
+    init(context: LiveContext<R>) {
+        self.context = context
+    }
+    
+    var body: some View {
+        SwiftUI.Picker(selection: $value) {
+            context.buildChildren(of: element, withTagName: "content", namespace: "picker", includeDefaultSlot: false)
+        } label: {
+            context.buildChildren(of: element, withTagName: "label", namespace: "picker", includeDefaultSlot: false)
+        }
+        .applyPickerStyle(element.attributeValue(for: "picker-style").flatMap(PickerStyle.init))
+    }
+    
+}
+
+private enum PickerStyle: String {
+    case automatic
+    case inline
+#if os(iOS) || os(macOS)
+    case menu
+#endif
+#if !os(macOS)
+    case navigationLink = "navigation-link"
+#endif
+#if os(macOS)
+    case radioGroup = "radio-group"
+#endif
+#if !os(watchOS)
+    case segmented
+#endif
+#if os(iOS) || os(watchOS)
+    case wheel
+#endif
+}
+
+private extension View {
+    @ViewBuilder
+    func applyPickerStyle(_ style: PickerStyle?) -> some View {
+        switch style {
+        case .automatic, nil:
+            self.pickerStyle(.automatic)
+        case .inline:
+            self.pickerStyle(.inline)
+#if os(iOS) || os(macOS)
+        case .menu:
+            self.pickerStyle(.menu)
+#endif
+#if !os(macOS)
+        case .navigationLink:
+            self.pickerStyle(.navigationLink)
+#endif
+#if os(macOS)
+        case .radioGroup:
+            self.pickerStyle(.radioGroup)
+#endif
+#if !os(watchOS)
+        case .segmented:
+            self.pickerStyle(.segmented)
+#endif
+#if os(iOS) || os(watchOS)
+        case .wheel:
+            self.pickerStyle(.wheel)
+#endif
+        }
+    }
+}

--- a/Tests/RenderingTests/PickerTests.swift
+++ b/Tests/RenderingTests/PickerTests.swift
@@ -43,4 +43,62 @@ final class PickerTests: XCTestCase {
         }
     }
 #endif
+    
+    func testPicker() throws {
+        try assertMatch(
+            #"""
+            <picker value="paperplane" picker-style="automatic">
+                <picker:label><text>Pick an icon</text></picker:label>
+                <picker:content>
+                    <label system-image="paperplane" modifiers='[{"type": "tag", "value": "paperplane"}]'><text>paperplane</text></label>
+                    <label system-image="graduationcap" modifiers='[{"type": "tag", "value": "graduationcap"}]'><text>graduationcap</text></label>
+                    <label system-image="ellipsis.bubble" modifiers='[{"type": "tag", "value": "ellipsis.bubble"}]'><text>ellipsis.bubble</text></label>
+                </picker:content>
+            </picker>
+            """#) {
+                Picker(selection: .constant("paperplane")) {
+                    ForEach(["paperplane", "graduationcap", "ellipsis.bubble"], id: \.self) { name in
+                        Label {
+                            Text(name)
+                                // the Picker imposes a slightly different font by default, but our Text view uses nil, so match that
+                                .font(nil)
+                        } icon: {
+                            Image(systemName: name)
+                        }
+                        .tag(name)
+                    }
+                } label: {
+                    Text("Pick an icon")
+                }
+                .pickerStyle(.automatic)
+        }
+        
+        try assertMatch(
+            #"""
+            <picker value="paperplane" picker-style="inline">
+                <picker:label><text>Pick an icon</text></picker:label>
+                <picker:content>
+                    <label system-image="paperplane" modifiers='[{"type": "tag", "value": "paperplane"}]'><text>paperplane</text></label>
+                    <label system-image="graduationcap" modifiers='[{"type": "tag", "value": "graduationcap"}]'><text>graduationcap</text></label>
+                    <label system-image="ellipsis.bubble" modifiers='[{"type": "tag", "value": "ellipsis.bubble"}]'><text>ellipsis.bubble</text></label>
+                </picker:content>
+            </picker>
+            """#) {
+                Picker(selection: .constant("paperplane")) {
+                    ForEach(["paperplane", "graduationcap", "ellipsis.bubble"], id: \.self) { name in
+                        Label {
+                            Text(name)
+                                // the Picker imposes a slightly different font by default, but our Text view uses nil, so match that
+                                .font(nil)
+                        } icon: {
+                            Image(systemName: name)
+                        }
+                        .tag(name)
+                    }
+                } label: {
+                    Text("Pick an icon")
+                }
+                .pickerStyle(.inline)
+        }
+    }
 }


### PR DESCRIPTION
Closes #72 

Right now, the tag modifier (and thus picker values) are limited to strings. I'd like to allow more complex types or any FormValue-conforming type in the future, but SwiftUI is really picky about the type of the picker's selection binding and the value passed into `.tag` lining up (e.g., if the binding is for a `String?` and the type passed into tag is a non-optional `String`, SwiftUI will think that there are picker options without tags).

Also, the [multi-source Picker initializers](https://developer.apple.com/documentation/swiftui/picker/init(sources:selection:content:label:)) aren't supported, since LVN doesn't have a concept of passing unspecified types and keypaths over the wire.

```html
<%= for style <- ["inline", "menu", "navigation-link", "segmented"] do %>
  <picker value-binding="picker_value" picker-style={style}>
    <picker:label>
      <text>Pick an icon</text>
    </picker:label>
    <picker:content>
      <%= for name <- ["lasso.and.sparkles", "paperplane", "tray.full", "doc.richtext", "graduationcap", "ellipsis.bubble"] do %>
        <label system-image={name} modifiers={[%{type: "tag", value: name}] |> Jason.encode!()}><text><%= name %></text></label>
      <% end %>
    </picker:content>
  </picker>
<% end %>
```

https://user-images.githubusercontent.com/7091588/219177928-6f609777-a493-4690-8599-b4a64a42d761.mp4

