### PR TITLE
Add font weight modifier

### DIFF
--- a/Sources/LiveViewNative/BuiltinRegistry.swift
+++ b/Sources/LiveViewNative/BuiltinRegistry.swift
@@ -131,6 +131,7 @@ struct BuiltinRegistry: BuiltinRegistryProtocol {
     }
     
     enum ModifierType: String {
+        case fontWeight = "font_weight"
         case frame
         case listRowInsets = "list_row_insets"
         case listRowSeparator = "list_row_separator"
@@ -148,6 +149,8 @@ struct BuiltinRegistry: BuiltinRegistryProtocol {
     @ViewModifierBuilder
     static func decodeModifier(_ type: ModifierType, from decoder: Decoder) throws -> some ViewModifier {
         switch type {
+        case .fontWeight:
+            try FontWeightModifier(from: decoder)
         case .frame:
             try FrameModifier(from: decoder)
         case .listRowInsets:

--- a/Sources/LiveViewNative/Modifiers/FontWeight.swift
+++ b/Sources/LiveViewNative/Modifiers/FontWeight.swift
@@ -9,32 +9,7 @@ import SwiftUI
 
 struct FontWeightModifier: ViewModifier, Decodable, Equatable {
     private let weight: Font.Weight?
-    
-    init(string value: String) {
-        switch value {
-        case "black":
-            self.weight = .black
-        case "bold":
-            self.weight = .bold
-        case "heavy":
-            self.weight = .heavy
-        case "light":
-            self.weight = .light
-        case "medium":
-            self.weight = .medium
-        case "regular":
-            self.weight = .regular
-        case "semibold":
-            self.weight = .semibold
-        case "thin":
-            self.weight = .thin
-        case "ultra_light":
-            self.weight = .ultraLight
-        default:
-            self = try! BuiltinRegistry.attributeDecoder.decode(FontWeightModifier.self, from: value.data(using: .utf8)!)
-        }
-    }
-    
+
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         switch try container.decode(String.self, forKey: .weight) {

--- a/Sources/LiveViewNative/Modifiers/FontWeight.swift
+++ b/Sources/LiveViewNative/Modifiers/FontWeight.swift
@@ -1,0 +1,75 @@
+//
+//  FontWeight.swift
+// LiveViewNative
+//
+//  Created by May Matyi on 2/17/23.
+//
+
+import SwiftUI
+
+struct FontWeightModifier: ViewModifier, Decodable, Equatable {
+    private let weight: Font.Weight?
+    
+    init(string value: String) {
+        switch value {
+        case "black":
+            self.weight = .black
+        case "bold":
+            self.weight = .bold
+        case "heavy":
+            self.weight = .heavy
+        case "light":
+            self.weight = .light
+        case "medium":
+            self.weight = .medium
+        case "regular":
+            self.weight = .regular
+        case "semibold":
+            self.weight = .semibold
+        case "thin":
+            self.weight = .thin
+        case "ultra_light":
+            self.weight = .ultraLight
+        default:
+            self = try! BuiltinRegistry.attributeDecoder.decode(FontWeightModifier.self, from: value.data(using: .utf8)!)
+        }
+    }
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        switch try container.decode(String.self, forKey: .weight) {
+        case "black":
+            self.weight = .black
+        case "bold":
+            self.weight = .bold
+        case "heavy":
+            self.weight = .heavy
+        case "light":
+            self.weight = .light
+        case "medium":
+            self.weight = .medium
+        case "regular":
+            self.weight = .regular
+        case "semibold":
+            self.weight = .semibold
+        case "thin":
+            self.weight = .thin
+        case "ultra_light":
+            self.weight = .ultraLight
+        default:
+            throw DecodingError.dataCorruptedError(forKey: .weight, in: container, debugDescription: "invalid value for weight")
+        }
+    }
+    
+    init(weight: Font.Weight) {
+        self.weight = weight
+    }
+
+    func body(content: Content) -> some View {
+        content.fontWeight(weight)
+    }
+    
+    enum CodingKeys: String, CodingKey {
+        case weight
+    }
+}

--- a/lib/live_view_native_swift_ui/modifiers/font_weight.ex
+++ b/lib/live_view_native_swift_ui/modifiers/font_weight.ex
@@ -1,0 +1,17 @@
+defmodule LiveViewNativeSwiftUi.Modifiers.FontWeight do
+  use LiveViewNativePlatform.Modifier
+
+  modifier_schema "font_weight" do
+    field :weight, Ecto.Enum, values: ~w(
+      black
+      bold
+      heavy
+      light
+      medium
+      regular
+      semibold
+      thin
+      ultra_light
+    )a
+  end
+end

--- a/lib/live_view_native_swift_ui/platform.ex
+++ b/lib/live_view_native_swift_ui/platform.ex
@@ -24,6 +24,7 @@ defmodule LiveViewNativeSwiftUi.Platform do
         modifiers: %LiveViewNativeSwiftUi.Modifiers{stack: []},
         platform_id: :ios,
         platform_modifiers: [
+          font_weight: Modifiers.FontWeight,
           frame: Modifiers.Frame,
           list_row_insets: Modifiers.ListRowInsets,
           list_row_separator: Modifiers.ListRowSeparator,


### PR DESCRIPTION
Adds support for the [`fontWeight`](https://developer.apple.com/documentation/swiftui/view/fontweight(_:)) modifier:

```elixir
<vstack id="modifiers-ios">
  <text modifiers={font_weight(@native, weight: :black)}>Black</text>
  <text modifiers={font_weight(@native, weight: :bold)}>Bold</text>
  <text modifiers={font_weight(@native, weight: :heavy)}>Heavy</text>
  <text modifiers={font_weight(@native, weight: :light)}>Light</text>
  <text modifiers={font_weight(@native, weight: :medium)}>Medium</text>
  <text modifiers={font_weight(@native, weight: :regular)}>Regular</text>
  <text modifiers={font_weight(@native, weight: :semibold)}>Semibold</text>
  <text modifiers={font_weight(@native, weight: :thin)}>Thin</text>
  <text modifiers={font_weight(@native, weight: :ultra_light)}>Ultra Light</text>
</vstack>
```

![Screenshot 2023-02-17 at 3 24 12 PM](https://user-images.githubusercontent.com/5893007/219816063-d92be615-7b46-4389-9742-2c380210493f.png)

Related issue: https://github.com/liveviewnative/liveview-client-swiftui/issues/183