### PR TITLE
Add ViewThatFits

### DIFF
--- a/Sources/LiveViewNative/BuiltinRegistry.swift
+++ b/Sources/LiveViewNative/BuiltinRegistry.swift
@@ -120,6 +120,8 @@ struct BuiltinRegistry: BuiltinRegistryProtocol {
             LazyHStack(element: element, context: context)
         case "picker":
             Picker(context: context)
+        case "view-that-fits":
+            ViewThatFits(element: element, context: context)
         case "phx-form":
             PhxForm<R>(element: element, context: context)
         case "phx-submit-button":

--- a/Sources/LiveViewNative/Views/Layout Containers/Sizing/ViewThatFits.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Sizing/ViewThatFits.swift
@@ -1,0 +1,25 @@
+//
+//  ViewThatFits.swift
+//
+//
+//  Created by Carson Katri on 2/21/23.
+//
+
+import SwiftUI
+
+struct ViewThatFits<R: CustomRegistry>: View {
+    @ObservedElement private var element: ElementNode
+    private let context: LiveContext<R>
+    
+    init(element: ElementNode, context: LiveContext<R>) {
+        self.context = context
+    }
+
+    public var body: some View {
+        SwiftUI.ViewThatFits(
+            in: element.attributeValue(for: "axes").flatMap(Axis.Set.init(string:)) ?? [.horizontal, .vertical]
+        ) {
+            context.buildChildren(of: element)
+        }
+    }
+}

--- a/Tests/RenderingTests/LayoutContainerTests.swift
+++ b/Tests/RenderingTests/LayoutContainerTests.swift
@@ -1,0 +1,46 @@
+//
+//  LayoutContainerTests.swift
+//
+//
+//  Created by Carson Katri on 2/21/23.
+//
+
+import XCTest
+import SwiftUI
+@testable import LiveViewNative
+
+@MainActor
+final class LayoutContainerTests: XCTestCase {
+    // MARK: ViewThatFits
+    
+    func testViewThatFits() throws {
+        try assertMatch(
+            #"""
+            <view-that-fits axes="horizontal">
+                <text>Long post content, takes up most of the space</text>
+                <text>Shorter version</text>
+            </view-that-fits>
+            """#,
+            size: .init(width: 300, height: 100)
+        ) {
+            ViewThatFits(in: .horizontal) {
+                Text("Long post content, takes up most of the space")
+                Text("Shorter version")
+            }
+        }
+        try assertMatch(
+            #"""
+            <view-that-fits>
+                <text>Long post content, takes up most of the space</text>
+                <text>Shorter version</text>
+            </view-that-fits>
+            """#,
+            size: .init(width: 500, height: 100)
+        ) {
+            ViewThatFits {
+                Text("Long post content, takes up most of the space")
+                Text("Shorter version")
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #109.

Chooses the first content that fits within the available space.
```html
<hstack>
  <image system-name="person.circle.fill" />
  <view-that-fits axes="horizontal">
    <text>Long post content, takes up most of the space</text>
    <text>Shorter version</text>
  </view-that-fits>
</hstack>
```
<img src="https://user-images.githubusercontent.com/13581484/220393895-c5afedd5-2d41-44f7-a1ec-505a62ef6f9e.png" width="300" />

But if we limit the size to `200`, it will choose the shorter version:
```html
<hstack modifiers={@native |> frame(width: 200)}>
  ...
</hstack>
```
<img src="https://user-images.githubusercontent.com/13581484/220394137-c9b97f0d-914b-4037-9495-2b5b5a7cf914.png" width="300" />