### PR TITLE
Add DisclosureGroup

### DIFF
--- a/Sources/LiveViewNative/BuiltinRegistry.swift
+++ b/Sources/LiveViewNative/BuiltinRegistry.swift
@@ -44,6 +44,10 @@ struct BuiltinRegistry: BuiltinRegistryProtocol {
         case "date-picker":
             DatePicker(context: context)
 #endif
+#if os(iOS) || os(macOS)
+        case "disclosure-group":
+            DisclosureGroup(context: context)
+#endif
         case "divider":
             Divider()
 #if os(iOS)

--- a/Sources/LiveViewNative/Views/Layout Containers/Groups/ControlGroup.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Groups/ControlGroup.swift
@@ -17,12 +17,10 @@ struct ControlGroup<R: CustomRegistry>: View {
     }
 
     public var body: some View {
-        SwiftUI.Group {
-            SwiftUI.ControlGroup {
-                context.buildChildren(of: element, withTagName: "content", namespace: "control-group", includeDefaultSlot: true)
-            } label: {
-                context.buildChildren(of: element, withTagName: "label", namespace: "control-group")
-            }
+        SwiftUI.ControlGroup {
+            context.buildChildren(of: element, withTagName: "content", namespace: "control-group", includeDefaultSlot: true)
+        } label: {
+            context.buildChildren(of: element, withTagName: "label", namespace: "control-group")
         }
         .applyControlGroupStyle(element.attributeValue(for: "control-group-style").flatMap(ControlGroupStyle.init) ?? .automatic)
     }

--- a/Sources/LiveViewNative/Views/Layout Containers/Groups/DisclosureGroup.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Groups/DisclosureGroup.swift
@@ -1,0 +1,44 @@
+//
+//  DisclosureGroup.swift
+//
+//
+//  Created by Carson Katri on 2/22/23.
+//
+
+#if os(iOS) || os(macOS)
+import SwiftUI
+
+struct DisclosureGroup<R: CustomRegistry>: View {
+    @ObservedElement private var element: ElementNode
+    private let context: LiveContext<R>
+    
+    @LiveBinding(attribute: "is-expanded") private var isExpanded = false
+
+    init(context: LiveContext<R>) {
+        self.context = context
+    }
+
+    public var body: some View {
+        SwiftUI.DisclosureGroup(isExpanded: $isExpanded) {
+            context.buildChildren(of: element, withTagName: "content", namespace: "disclosure-group", includeDefaultSlot: true)
+        } label: {
+            context.buildChildren(of: element, withTagName: "label", namespace: "disclosure-group", includeDefaultSlot: false)
+        }
+        .applyDisclosureGroupStyle(element.attributeValue(for: "disclosure-group-style").flatMap(DisclosureGroupStyle.init) ?? .automatic)
+    }
+}
+
+fileprivate enum DisclosureGroupStyle: String {
+    case automatic
+}
+
+fileprivate extension View {
+    @ViewBuilder
+    func applyDisclosureGroupStyle(_ style: DisclosureGroupStyle) -> some View {
+        switch style {
+        case .automatic:
+            self.disclosureGroupStyle(.automatic)
+        }
+    }
+}
+#endif

--- a/Tests/RenderingTests/GroupTests.swift
+++ b/Tests/RenderingTests/GroupTests.swift
@@ -149,5 +149,40 @@ final class GroupTests: XCTestCase {
             .controlGroupStyle(.navigation)
         }
     }
+    
+    // MARK: DisclosureGroup
+    func testDisclosureGroup() throws {
+        try assertMatch(
+            #"""
+            <disclosure-group>
+                <disclosure-group:label>Expandable Section</disclosure-group:label>
+                Content
+            </disclosure-group>
+            """#
+        ) {
+            DisclosureGroup {
+                Text("Content")
+            } label: {
+                Text("Expandable Section")
+            }
+        }
+    }
+    
+    func testDisclosureGroupSlots() throws {
+        try assertMatch(
+            #"""
+            <disclosure-group>
+                <disclosure-group:label>Expandable Section</disclosure-group:label>
+                <disclosure-group:content>Content</disclosure-group:content>
+            </disclosure-group>
+            """#
+        ) {
+            DisclosureGroup {
+                Text("Content")
+            } label: {
+                Text("Expandable Section")
+            }
+        }
+    }
 #endif
 }


### PR DESCRIPTION
Closes #206 

A live binding can be used with the `is-expanded` attribute, allowing the group to be opened/closed in sync with another action, such as a toggle.

```html
<toggle value-binding="is_on" />
<disclosure-group modifiers={padding(@native, all: 16)} is-expanded="is_on">
  <disclosure-group:label>
    This is the label
  </disclosure-group:label>
  <text>Hello, world!</text>
</disclosure-group>
```

https://user-images.githubusercontent.com/13581484/220772820-570fef31-d528-4e56-a4e4-d887f285d3be.mp4


It also plays well with `List` out of the box:

```html
<list>
  <disclosure-group id="root">
    <disclosure-group:label>
      📂 Documents
    </disclosure-group:label>
    <disclosure-group>
      <disclosure-group:label>
        📂 Projects
      </disclosure-group:label>
      <disclosure-group>
        <disclosure-group:label>
          📂 LiveViewNative
        </disclosure-group:label>
        <text>📄 Text.swift</text>
        <text>📄 Button.swift</text>
        <text>📄 README.md</text>
      </disclosure-group>
    </disclosure-group>
    <text>📄 welcome.txt</text>
  </disclosure-group>
</list>
```

https://user-images.githubusercontent.com/13581484/220773003-5e127487-df31-47a3-aaea-6cc3edf2b0fb.mp4
