### PR TITLE
Add `LabeledContent`

### DIFF
--- a/Sources/LiveViewNative/BuiltinRegistry.swift
+++ b/Sources/LiveViewNative/BuiltinRegistry.swift
@@ -80,6 +80,8 @@ struct BuiltinRegistry: BuiltinRegistryProtocol {
             Image(element: element, context: context)
         case "label":
             Label(element: element, context: context)
+        case "labeled-content":
+            LabeledContent(context: context)
         case "lazy-h-grid":
             LazyHGrid(element: element, context: context)
         case "lazy-h-stack", "lazy-hstack":

--- a/Sources/LiveViewNative/Views/Layout Containers/Forms/LabeledContent.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Forms/LabeledContent.swift
@@ -16,10 +16,20 @@ struct LabeledContent<R: CustomRegistry>: View {
     }
     
     var body: some View {
-        SwiftUI.LabeledContent {
-            context.buildChildren(of: element, withTagName: "content", namespace: "labeled-content", includeDefaultSlot: true)
-        } label: {
-            context.buildChildren(of: element, withTagName: "label", namespace: "labeled-content")
+        SwiftUI.Group {
+            if element.attributeValue(for: "format") != nil {
+                SwiftUI.LabeledContent {
+                    Text(context: context)
+                } label: {
+                    context.buildChildren(of: element)
+                }
+            } else {
+                SwiftUI.LabeledContent {
+                    context.buildChildren(of: element, withTagName: "content", namespace: "labeled-content", includeDefaultSlot: true)
+                } label: {
+                    context.buildChildren(of: element, withTagName: "label", namespace: "labeled-content")
+                }
+            }
         }
         .applyLabeledContentStyle(element.attributeValue(for: "labeled-content-style").flatMap(LabeledContentStyle.init) ?? .automatic)
     }

--- a/Sources/LiveViewNative/Views/Layout Containers/Forms/LabeledContent.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Forms/LabeledContent.swift
@@ -1,0 +1,39 @@
+//
+//  LabeledContent.swift
+//  
+//
+//  Created by Carson.Katri on 2/23/23.
+//
+
+import SwiftUI
+
+struct LabeledContent<R: CustomRegistry>: View {
+    @ObservedElement private var element
+    private let context: LiveContext<R>
+    
+    init(context: LiveContext<R>) {
+        self.context = context
+    }
+    
+    var body: some View {
+        SwiftUI.LabeledContent {
+            context.buildChildren(of: element, withTagName: "content", namespace: "labeled-content", includeDefaultSlot: true)
+        } label: {
+            context.buildChildren(of: element, withTagName: "label", namespace: "labeled-content")
+        }
+        .applyLabeledContentStyle(element.attributeValue(for: "labeled-content-style").flatMap(LabeledContentStyle.init) ?? .automatic)
+    }
+}
+
+private enum LabeledContentStyle: String {
+    case automatic
+}
+
+private extension View {
+    @ViewBuilder
+    func applyLabeledContentStyle(_ style: LabeledContentStyle) -> some View {
+        switch style {
+        case .automatic: self.labeledContentStyle(.automatic)
+        }
+    }
+}

--- a/Tests/RenderingTests/FormTests.swift
+++ b/Tests/RenderingTests/FormTests.swift
@@ -1,0 +1,113 @@
+//
+//  FormTests.swift
+//
+//
+//  Created by Carson Katri on 2/23/23.
+//
+
+import XCTest
+import SwiftUI
+@testable import LiveViewNative
+
+@MainActor
+final class FormTests: XCTestCase {
+    // MARK: Form
+
+    func testForm() throws {
+        try assertMatch(
+            #"""
+            <form>
+                <text id="0">0</text>
+                <text id="1">1</text>
+                <text id="2">2</text>
+            </form>
+            """#,
+            size: .init(width: 300, height: 300)
+        ) {
+            Form {
+                Text("0")
+                Text("1")
+                Text("2")
+            }
+        }
+    }
+
+    func testFormStyles() throws {
+        let markupContent = #"""
+        <text id="0">0</text>
+        <text id="1">1</text>
+        <text id="2">2</text>
+        """#
+        @ViewBuilder
+        var content: some View {
+            Text("0")
+            Text("1")
+            Text("2")
+        }
+        try assertMatch(
+            #"<form form-style="automatic">\#(markupContent)</form>"#,
+            size: .init(width: 300, height: 300)
+        ) {
+            Form {
+                content
+            }
+            .formStyle(.automatic)
+        }
+        try assertMatch(
+            #"<form form-style="columns">\#(markupContent)</form>"#,
+            size: .init(width: 300, height: 300)
+        ) {
+            Form {
+                content
+            }
+            .formStyle(.columns)
+        }
+        try assertMatch(
+            #"<form form-style="grouped">\#(markupContent)</form>"#,
+            size: .init(width: 300, height: 300)
+        ) {
+            Form {
+                content
+            }
+            .formStyle(.grouped)
+        }
+    }
+    
+    // MARK: LabeledContent
+    
+    func testLabeledContent() throws {
+        try assertMatch(
+            #"""
+            <labeled-content>
+                <labeled-content:label>Label</labeled-content:label>
+                Content
+            </labeled-content>
+            """#,
+            size: .init(width: 300, height: 100)
+        ) {
+            LabeledContent {
+                Text("Content")
+            } label: {
+                Text("Label")
+            }
+        }
+    }
+    
+    func testLabeledContentSlots() throws {
+        try assertMatch(
+            #"""
+            <labeled-content>
+                <labeled-content:label>Label</labeled-content:label>
+                <labeled-content:content>Content</labeled-content:content>
+            </labeled-content>
+            """#,
+            size: .init(width: 300, height: 100)
+        ) {
+            LabeledContent {
+                Text("Content")
+            } label: {
+                Text("Label")
+            }
+        }
+    }
+}

--- a/Tests/RenderingTests/FormTests.swift
+++ b/Tests/RenderingTests/FormTests.swift
@@ -110,4 +110,13 @@ final class FormTests: XCTestCase {
             }
         }
     }
+    
+    func testLabeledContentFormat() throws {
+        try assertMatch(
+            #"<labeled-content value="100" format="currency" currency-code="usd">Label</labeled-content>"#,
+            size: .init(width: 300, height: 100)
+        ) {
+            LabeledContent("Label", value: 100, format: .currency(code: "usd"))
+        }
+    }
 }


### PR DESCRIPTION
Closes #116 

You can initialize with a View, or with a value/format like the Text view accepts.

```html
<form>
  <labeled-content value={3_400} format="number">Δv</labeled-content>
  <labeled-content value={6_000_000} format="currency" currency-code="usd">Cost</labeled-content>
  <labeled-content value={DateTime.utc_now()} format="date-time">Launch Date</labeled-content>

  <labeled-content>
    <labeled-content:label>Part Count</labeled-content:label>
    <labeled-content:content>
      <hstack>
        <button phx-click="decrement">-</button>
        <divider />
        <button phx-click="increment">+</button>
      </hstack>
    </labeled-content:content>
  </labeled-content>
</form>
```

<img src="https://user-images.githubusercontent.com/13581484/220942829-339cf8b7-89d3-4c7c-b49c-306743c50049.png" width="300" />
