### PR TITLE
Add aggregate registry

### DIFF
--- a/Sources/LiveViewNative/Coordinators/LiveNavigationEntry.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveNavigationEntry.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct LiveNavigationEntry<R: CustomRegistry>: Hashable {
+struct LiveNavigationEntry<R: RootRegistry>: Hashable {
     let url: URL
     let coordinator: LiveViewCoordinator<R>
     

--- a/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
@@ -17,10 +17,10 @@ private let logger = Logger(subsystem: "LiveViewNative", category: "LiveSessionC
 
 /// The session coordinator object handles the initial connection, as well as navigation.
 @MainActor
-public class LiveSessionCoordinator<R: CustomRegistry>: ObservableObject {
+public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
     @Published internal private(set) var internalState: InternalState = .notConnected(reconnectAutomatically: false)
     /// The current state of the live view connection.
-    public var state: State {
+    public var state: LiveSessionState {
         internalState.publicState
     }
     
@@ -324,7 +324,7 @@ extension LiveSessionCoordinator {
         case connected
         case connectionFailed(Error)
         
-        var publicState: State {
+        var publicState: LiveSessionState {
             switch self {
             case .notConnected(reconnectAutomatically: _):
                 return .notConnected
@@ -353,17 +353,5 @@ extension LiveSessionCoordinator {
                 return true
             }
         }
-    }
-    /// The live view connection state.
-    public enum State {
-        /// The coordinator has not yet connected to the live view.
-        case notConnected
-        /// The coordinator is attempting to connect.
-        case connecting
-        /// The coordinator has connected and the view tree can be rendered.
-        case connected
-        // todo: disconnected state?
-        /// The coordinator failed to connect and produced the given error.
-        case connectionFailed(Error)
     }
 }

--- a/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveSessionCoordinator.swift
@@ -80,7 +80,7 @@ public class LiveSessionCoordinator<R: RootRegistry>: ObservableObject {
     
     /// Connects this coordinator to the LiveView channel.
     ///
-    /// This function is a no-op unless ``state-swift.property`` is ``State-swift.enum/notConnected``.
+    /// This function is a no-op unless ``state`` is ``LiveSessionState/notConnected``.
     ///
     /// This is an async function which completes when the connection has been established or failed.
     public func connect() async {

--- a/Sources/LiveViewNative/Coordinators/LiveSessionState.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveSessionState.swift
@@ -1,0 +1,21 @@
+//
+//  LiveSessionState.swift
+//  LiveViewNative
+//
+//  Created by Shadowfacts on 2/23/23.
+//
+
+import Foundation
+
+/// The live view connection state.
+public enum LiveSessionState {
+    /// The coordinator has not yet connected to the live view.
+    case notConnected
+    /// The coordinator is attempting to connect.
+    case connecting
+    /// The coordinator has connected and the view tree can be rendered.
+    case connected
+    // todo: disconnected state?
+    /// The coordinator failed to connect and produced the given error.
+    case connectionFailed(Error)
+}

--- a/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
+++ b/Sources/LiveViewNative/Coordinators/LiveViewCoordinator.swift
@@ -24,10 +24,10 @@ private let logger = Logger(subsystem: "LiveViewNative", category: "LiveViewCoor
 /// - ``receiveEvent(_:)``
 /// - ``handleEvent(_:handler:)``
 @MainActor
-public class LiveViewCoordinator<R: CustomRegistry>: ObservableObject {
+public class LiveViewCoordinator<R: RootRegistry>: ObservableObject {
     @Published internal private(set) var internalState: LiveSessionCoordinator<R>.InternalState = .notConnected(reconnectAutomatically: false)
     
-    var state: LiveSessionCoordinator<R>.State {
+    var state: LiveSessionState {
         internalState.publicState
     }
     

--- a/Sources/LiveViewNative/LiveContext.swift
+++ b/Sources/LiveViewNative/LiveContext.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import LiveViewNativeCore
 
 /// The context provides information at initialization-time to views in a LiveView.
-public struct LiveContext<R: CustomRegistry> {
+public struct LiveContext<R: RootRegistry> {
     /// The coordinator corresponding to the live view in which thie view is being constructed.
     public let coordinator: LiveViewCoordinator<R>
     

--- a/Sources/LiveViewNative/LiveView.swift
+++ b/Sources/LiveViewNative/LiveView.swift
@@ -12,7 +12,7 @@ import SwiftUI
 ///
 /// The `LiveView` attempts to connect immediately when it appears.
 ///
-/// While in states other than ``LiveSessionCoordinator/State-swift.enum/connected``, this view only provides a basic text description of the state. The loading view can be customized with a custom registry and the ``CustomRegistry/loadingView(for:state:)-33lst`` method.
+/// While in states other than ``LiveSessionState/connected``, this view only provides a basic text description of the state. The loading view can be customized with a custom registry and the ``CustomRegistry/loadingView(for:state:)-6jd3b`` method.
 ///
 /// ## Topics
 /// ### Creating a LiveView

--- a/Sources/LiveViewNative/LiveView.swift
+++ b/Sources/LiveViewNative/LiveView.swift
@@ -21,7 +21,7 @@ import SwiftUI
 /// - ``body``
 /// ### See Also
 /// - ``LiveViewModel``
-public struct LiveView<R: CustomRegistry>: View {
+public struct LiveView<R: RootRegistry>: View {
     @State private var hasAppeared = false
     @ObservedObject var session: LiveSessionCoordinator<R>
     @State private var hasSetupNavigationControllerDelegate = false

--- a/Sources/LiveViewNative/LiveViewNative.docc/AddCustomElement.md
+++ b/Sources/LiveViewNative/LiveViewNative.docc/AddCustomElement.md
@@ -1,32 +1,32 @@
 # Adding Custom Elements
 
-Use the ``CustomRegistry`` protocol to define how DOM elements are converted to SwiftUI views.
+Use the ``RootRegistry`` protocol to define how DOM elements are converted to SwiftUI views.
 
 ## Overview
 
-If you don't already have one, create a type that conforms to the ``CustomRegistry`` protocol and provide it as the generic type parameter to your ``LiveViewCoordinator``.
+If you don't already have one, create a type that conforms to the ``RootRegistry`` protocol and provide it as the generic type parameter to your ``LiveViewCoordinator``.
 
 ```swift
-struct MyRegistry: CustomRegistry {
+struct MyRegistry: RootRegistry {
 }
 ```
 
 Then, add an enum type called `TagName` that has strings for raw values. This type is what the framework uses to check if your custom registry supports a given tag name. All of the string values should be lowercase, otherwise the framework will not support them. In the following example, `<my-tag>` elements in the DOM will be converted to the `.myTag` name.
 
 ```swift
-struct MyRegistry: CustomRegistry {
+struct MyRegistry: RootRegistry {
     enum TagName: String {
         case myTag = "my-tag"
     }
 }
 ```
 
-To provide views for these elements, implement the ``CustomRegistry/lookup(_:element:context:)-895au`` method. Your implementation of this method is automatically treated as SwiftUI `ViewBuilder`, so simply construct the view you want to use rather than returning it.
+To provide views for these elements, implement the ``CustomRegistry/lookup(_:element:context:)-5bvqg`` method. Your implementation of this method is automatically treated as SwiftUI `ViewBuilder`, so simply construct the view you want to use rather than returning it.
 
 In the following example, the element `<my-tag />` in the DOM will be displayed as the text "My custom element!"
 
 ```swift
-struct MyRegistry: CustomRegistry {
+struct MyRegistry: RootRegistry {
     enum TagName: String {
         case myTag = "my-tag"
     }

--- a/Sources/LiveViewNative/LiveViewNative.docc/AddCustomModifier.md
+++ b/Sources/LiveViewNative/LiveViewNative.docc/AddCustomModifier.md
@@ -1,32 +1,32 @@
 # Adding Custom Modifiers
 
-Use the ``CustomRegistry`` protocol to define how custom modifiers in the DOM are handled.
+Use the ``RootRegistry`` protocol to define how custom modifiers in the DOM are handled.
 
 ## Overview
 
-If you don't already have one, create a type that conforms to the ``CustomRegistry`` protocol and provide it as the eneric type paramter to your ``LiveViewCoordinator``.
+If you don't already have one, create a type that conforms to the ``RootRegistry`` protocol and provide it as the eneric type paramter to your ``LiveViewCoordinator``.
 
 ```swift
-struct MyRegistry: CustomRegistry {
+struct MyRegistry: RootRegistry {
 }
 ```
 
 Then, add an enum called `AttributeName` that has strings for raw values and conforms to `Equatable`. The framework will use this type to check if your registry supports a particular attribute name. All of the string values should be lowercase, otherwise the framework will not use them.
 
 ```swift
-struct MyRegistry: CustomRegistry {
+struct MyRegistry: RootRegistry {
     enum ModifierType: String {
         case myFont = "my_font"
     }
 }
 ```
 
-To define the view modifier for this attributes, implement the ``CustomRegistry/decodeModifier(_:from:context:)-35xcx`` method. This method is automatically treated as a ``ViewModifierBuilder``, so simply construct your modifier rather than returning it.
+To define the view modifier for this attributes, implement the ``CustomRegistry/decodeModifier(_:from:context:)-4cqvs`` method. This method is automatically treated as a ``ViewModifierBuilder``, so simply construct your modifier rather than returning it.
 
 In the following example, a modifier like `{"type": "my_font", "size": 22}` could be used to apply the custom font named "My Font" with a fixed size of 22pt.
 
 ```swift
-struct MyRegistry: CustomRegistry {
+struct MyRegistry: RootRegistry {
     enum ModifierType: String {
         case myFont = "my_font"
     }

--- a/Sources/LiveViewNative/LiveViewNative.docc/Elements/NavigationLink.md
+++ b/Sources/LiveViewNative/LiveViewNative.docc/Elements/NavigationLink.md
@@ -5,7 +5,7 @@
 ## Attributes
 
 - `data-phx-link`: Must be `redirect`
-- `data-phx-link-state`: How the link is presented. See ``LiveViewConfiguration/navigationMode-swift.property``.
+- `data-phx-link-state`: How the link is presented. See ``LiveSessionConfiguration/navigationMode-swift.property``.
     - `push`: A new view is pushed onto the navigation stack
     - `replace`: The current view is replaced.
 - `data-phx-href`: The link destination.

--- a/Sources/LiveViewNative/LiveViewNative.docc/SupportedModifiers.md
+++ b/Sources/LiveViewNative/LiveViewNative.docc/SupportedModifiers.md
@@ -14,7 +14,7 @@ These attributes are supported by all elements, including custom ones. Modifiers
 
 ## Attributes
 
-- `navigation_title`: The navigation title of the current page. Only displayed when navgiation is enabled, see ``LiveViewConfiguration/navigationMode-swift.property``. Properties:
+- `navigation_title`: The navigation title of the current page. Only displayed when navgiation is enabled, see ``LiveSessionConfiguration/navigationMode-swift.property``. Properties:
     - `title` (string): The navigation title.
 - `frame`: A fixed size or flexible size frame around the modified view. Note that the fixed and flexible properties are mutually exclusive. All properties are optional. Properties:
     - `width` (number): The width of the frame.

--- a/Sources/LiveViewNative/NavStackEntryView.swift
+++ b/Sources/LiveViewNative/NavStackEntryView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 import LiveViewNativeCore
 
-struct NavStackEntryView<R: CustomRegistry>: View {
+struct NavStackEntryView<R: RootRegistry>: View {
     private let entry: LiveNavigationEntry<R>
     @ObservedObject private var coordinator: LiveViewCoordinator<R>
     @StateObject private var liveViewModel = LiveViewModel()

--- a/Sources/LiveViewNative/Property Wrappers/LiveBinding.swift
+++ b/Sources/LiveViewNative/Property Wrappers/LiveBinding.swift
@@ -20,7 +20,7 @@ import Combine
 ///
 /// Depending on how the live binding is used, the name is obtained in one of two ways:
 /// 1. If it is being used as part of an element, the binding name is provided by an attribute on the element.
-/// Pass the name of the attribute which specifies the binding name to the ``LiveBinding/init(attribute:)`` initializer.
+/// Pass the name of the attribute which specifies the binding name to the ``LiveBinding/init(wrappedValue:attribute:)`` initializer.
 /// 2. If it is being used as part of a view modifier, the binding name is encoded as a string in the modifier payload.
 /// Decode the binding using the ``init(decoding:in:initialValue:)`` initializer, and the string value at the given coding key will be used as the binding name.
 ///

--- a/Sources/LiveViewNative/Registries/AggregateRegistry.swift
+++ b/Sources/LiveViewNative/Registries/AggregateRegistry.swift
@@ -1,0 +1,91 @@
+//
+//  AggregateRegistry.swift
+//  LiveViewNative
+//
+//  Created by Shadowfacts on 2/23/23.
+//
+
+import Foundation
+import SwiftUI
+
+public protocol AggregateRegistry: RootRegistry {
+    associatedtype Registries: CustomRegistry where Registries.Root == Self
+}
+
+extension AggregateRegistry {
+    public static func lookup(_ name: Registries.TagName, element: ElementNode, context: LiveContext<Root>) -> some View {
+        return Registries.lookup(name, element: element, context: context)
+    }
+
+    public static func decodeModifier(_ type: Registries.ModifierType, from decoder: Decoder, context: LiveContext<Root>) throws -> some ViewModifier {
+        return try Registries.decodeModifier(type, from: decoder, context: context)
+    }
+
+    public static func loadingView(for url: URL, state: LiveSessionState) -> some View {
+        return Registries.loadingView(for: url, state: state)
+    }
+}
+
+public enum _EitherRawString<First: RawRepresentable<String>, Second: RawRepresentable<String>>: RawRepresentable {
+    case first(First)
+    case second(Second)
+
+    public init?(rawValue: String) {
+        if let name = First(rawValue: rawValue) {
+            self = .first(name)
+        } else if let name = Second(rawValue: rawValue) {
+            self = .second(name)
+        } else {
+            return nil
+        }
+    }
+
+    public var rawValue: String {
+        switch self {
+        case .first(let name):
+            return name.rawValue
+        case .second(let name):
+            return name.rawValue
+        }
+    }
+}
+
+@frozen public struct _MultiRegistry<First: CustomRegistry, Second: CustomRegistry>: CustomRegistry where First.Root == Second.Root {
+    public typealias Root = First.Root
+    
+    public typealias TagName = _EitherRawString<First.TagName, Second.TagName>
+
+    public static func lookup(_ name: TagName, element: ElementNode, context: LiveContext<First.Root>) -> some View {
+        switch name {
+        case .first(let name):
+            First.lookup(name, element: element, context: context)
+        case .second(let name):
+            Second.lookup(name, element: element, context: context)
+        }
+    }
+
+    public typealias ModifierType = _EitherRawString<First.ModifierType, Second.ModifierType>
+
+    public static func decodeModifier(_ type: ModifierType, from decoder: Decoder, context: LiveContext<First.Root>) throws -> some ViewModifier {
+        switch type {
+        case .first(let type):
+            try First.decodeModifier(type, from: decoder, context: context)
+        case .second(let type):
+            try Second.decodeModifier(type, from: decoder, context: context)
+        }
+    }
+
+    public static func loadingView(for url: URL, state: LiveSessionState) -> some View {
+        return First.loadingView(for: url, state: state)
+    }
+}
+
+public typealias Registry2<T0: CustomRegistry, T1: CustomRegistry>
+    = _MultiRegistry<T0, T1>
+    where T0.Root == T1.Root
+public typealias Registry3<T0: CustomRegistry, T1: CustomRegistry, T2: CustomRegistry>
+    = _MultiRegistry<_MultiRegistry<T0, T1>, T2>
+    where T0.Root == T1.Root, T0.Root == T2.Root
+public typealias Registry4<T0: CustomRegistry, T1: CustomRegistry, T2: CustomRegistry, T3: CustomRegistry>
+    = _MultiRegistry<_MultiRegistry<T0, T1>, _MultiRegistry<T2, T3>>
+    where T0.Root == T1.Root, T0.Root == T2.Root, T0.Root == T3.Root

--- a/Sources/LiveViewNative/Registries/AggregateRegistry.swift
+++ b/Sources/LiveViewNative/Registries/AggregateRegistry.swift
@@ -8,7 +8,60 @@
 import Foundation
 import SwiftUI
 
+/// An aggregate registry combines multiple other registries together, allowing you to use tags/modifiers declared by any of them.
+///
+/// To conform to this protocol, provide the `Registries` typealias, using the `Registry2`/`Registry3`/etc. types:
+/// ```swift
+/// struct AppRegistries: AggregateRegistry {
+///     typealias Registries = Registry2<
+///         MyRegistry,
+///         LiveFormsRegistry<Self>
+///     >
+/// }
+/// ```
+///
+/// To use your aggregate registry, pass it as the type parameter when you're constructing the ``LiveSessionCoordinator``:
+/// ```swift
+/// struct ContentView: View {
+///     @State var session = LiveSessionCoordinator<AppRegistries>(url: URL(string: "...")!)
+/// }
+/// ```
+///
+/// Note that each of the registry types used in the aggregate registry must specify that its root registry type is your aggregate registry.
+/// This is required so that inside of an element provided by one registry, there can also be elements provided by any of the other registries that are aggregated together.
+///
+/// If you're implementing a registry for use within your own app, you can specify the root registry explicitly:
+/// ```swift
+/// struct MyRegistry: CustomRegistry {
+///     typealias Root = AppRegistries
+///     // ...
+/// }
+/// ```
+/// Or, if you're implementing a registry as part of a library that will be used by another app, you can make your registry type generic over the root type:
+/// ```swift
+/// struct LiveFormsRegistry<Root: RootRegistry>: CustomRegistry {
+///     // ...
+/// }
+/// ```
+///
+/// ### Loading Views
+/// Whereas tags and modifiers can be composed from multiple registry types without conflict, only one loading view implementation can be used.
+/// The aggregate registry will use the loading view from the first concrete registry type that is provided.
+/// In the above example, `AppRegistries` would use `MyRegistry`'s loading view by default.
+///
+/// If you don't want this behavior, you can override ``CustomRegistry/loadingView(for:state:)-6jd3b`` on your aggregate registry and provide another view.
+///
+/// ## Topics
+/// ### Protocol Requirements
+/// - ``Registries``
+/// ### Multi-Registry Types
+/// - ``Registry2``
+/// - ``Registry3``
+/// - ``Registry4``
 public protocol AggregateRegistry: RootRegistry {
+    /// The combined registry type.
+    ///
+    /// - Note: The ``CustomRegistry/Root`` associated type of the combined registry must be your aggregate registry.
     associatedtype Registries: CustomRegistry where Registries.Root == Self
 }
 
@@ -26,6 +79,7 @@ extension AggregateRegistry {
     }
 }
 
+/// A helper type that represents either one of two `RawRepresentable<String>` types.
 public enum _EitherRawString<First: RawRepresentable<String>, Second: RawRepresentable<String>>: RawRepresentable {
     case first(First)
     case second(Second)
@@ -50,6 +104,7 @@ public enum _EitherRawString<First: RawRepresentable<String>, Second: RawReprese
     }
 }
 
+/// A registry implementation that combines two registries. Use the `Registry2`/etc. typealiases rather than using this type directly.
 @frozen public struct _MultiRegistry<First: CustomRegistry, Second: CustomRegistry>: CustomRegistry where First.Root == Second.Root {
     public typealias Root = First.Root
     
@@ -80,12 +135,15 @@ public enum _EitherRawString<First: RawRepresentable<String>, Second: RawReprese
     }
 }
 
+/// A registry type that combines 2 registries.
 public typealias Registry2<T0: CustomRegistry, T1: CustomRegistry>
     = _MultiRegistry<T0, T1>
     where T0.Root == T1.Root
+///A registry type that combines 3 registries.
 public typealias Registry3<T0: CustomRegistry, T1: CustomRegistry, T2: CustomRegistry>
     = _MultiRegistry<_MultiRegistry<T0, T1>, T2>
     where T0.Root == T1.Root, T0.Root == T2.Root
+/// A registry type that combines 4 registries.
 public typealias Registry4<T0: CustomRegistry, T1: CustomRegistry, T2: CustomRegistry, T3: CustomRegistry>
     = _MultiRegistry<_MultiRegistry<T0, T1>, _MultiRegistry<T2, T3>>
     where T0.Root == T1.Root, T0.Root == T2.Root, T0.Root == T3.Root

--- a/Sources/LiveViewNative/Registries/BuiltinRegistry.swift
+++ b/Sources/LiveViewNative/Registries/BuiltinRegistry.swift
@@ -20,7 +20,7 @@ struct BuiltinRegistry: BuiltinRegistryProtocol {
     static let attributeDecoder = JSONDecoder()
     
     @ViewBuilder
-    static func lookup<R: CustomRegistry>(_ name: String, _ element: ElementNode, context: LiveContext<R>) -> some View {
+    static func lookup<R: RootRegistry>(_ name: String, _ element: ElementNode, context: LiveContext<R>) -> some View {
         switch name {
         case "async-image":
             AsyncImage(element: element, context: context)

--- a/Sources/LiveViewNative/Registries/CustomRegistry.swift
+++ b/Sources/LiveViewNative/Registries/CustomRegistry.swift
@@ -10,9 +10,10 @@ import LiveViewNativeCore
 
 /// A custom registry allows clients to include custom view types in the LiveView DOM.
 ///
-/// To add a custom element or attribute, define an enum for the type alias for the tag/attribute name and implement the appropriate method. To customize the loading view, implement the ``loadingView(for:state:)-33lst`` method.
+/// To add a custom element or attribute, define an enum for the type alias for the tag/attribute name and implement the appropriate method. To customize the loading view, implement the ``loadingView(for:state:)-6jd3b`` method.
 ///
-/// To use your custom registry implementation, provide it as the generic parameter for the ``LiveSessionCoordinator`` you construct:
+/// To use a single registry, implement the ``RootRegistry`` protocol and implement the inherited `CustomRegistry` requirements. If you want to combine multiple registries, see ``AggregateRegistry``.
+/// To use your registry, provide it as the generic parameter for the ``LiveSessionCoordinator`` you construct:
 ///
 /// ```swift
 /// struct ContentView: View {
@@ -23,19 +24,28 @@ import LiveViewNativeCore
 /// ## Topics
 /// ### Custom Tags
 /// - ``TagName``
-/// - ``lookup(_:element:context:)-895au``
+/// - ``lookup(_:element:context:)-5bvqg``
 /// - ``CustomView``
 /// ### Custom View Modifiers
 /// - ``ModifierType``
-/// - ``decodeModifier(_:from:context:)-35xcx``
+/// - ``decodeModifier(_:from:context:)-4cqvs``
 /// - ``CustomModifier``
 /// ### Customizing the Loading View
-/// - ``loadingView(for:state:)-33lst``
+/// - ``loadingView(for:state:)-6jd3b``
 /// - ``LoadingView``
+/// ### Composing Registries
+/// - ``AggregateRegistry``
+/// - ``RootRegistry``
+/// - ``Root``
 /// ### Supporting Types
 /// - ``EmptyRegistry``
 /// - ``ViewModifierBuilder``
 public protocol CustomRegistry {
+    /// The root custom registry type that the live view coordinator and context use.
+    ///
+    /// Conform you registry type to ``RootRegistry``, which sets this type to `Self` automatically, if you intend to use your registry directly.
+    ///
+    /// If you are composing multiple custom registries together or building a registry intended to incorporated into an aggregated registry, see ``AggregateRegistry``.
     associatedtype Root: RootRegistry
     
     /// A type representing the tag names that this registry type can provide views for.
@@ -44,7 +54,7 @@ public protocol CustomRegistry {
     ///
     /// Generally, this is an enum which declares variants for the supported tags:
     /// ```swift
-    /// struct MyRegistry: CustomRegistry {
+    /// struct MyRegistry: RootRegistry {
     ///     enum TagName: String {
     ///         case foo
     ///         case barBaz = "bar-baz"
@@ -60,7 +70,7 @@ public protocol CustomRegistry {
     ///
     /// Generally, this is an enum which declares variants for the support attributes:
     /// ```swift
-    /// struct MyRegistry: CustomRegistry {
+    /// struct MyRegistry: RootRegistry {
     ///     enum AttributeName: String {
     ///         case foo
     ///         case barBaz
@@ -72,15 +82,15 @@ public protocol CustomRegistry {
     associatedtype ModifierType: RawRepresentable = EmptyRegistry.None where ModifierType.RawValue == String
     /// The type of view this registry returns from the `lookup` method.
     ///
-    /// Generally, implementors will use an opaque return type on their ``lookup(_:element:context:)-895au`` implementations and this will be inferred automatically.
+    /// Generally, implementors will use an opaque return type on their ``lookup(_:element:context:)-5bvqg`` implementations and this will be inferred automatically.
     associatedtype CustomView: View = Never
     /// The type of view modifier this registry returns from the `decodeModifiers` method.
     ///
-    /// Generally, implementors will use an opaque return type on their ``decodeModifier(_:from:context:)-35xcx`` implementations and this will be inferred automatically.
+    /// Generally, implementors will use an opaque return type on their ``decodeModifier(_:from:context:)-4cqvs`` implementations and this will be inferred automatically.
     associatedtype CustomModifier: ViewModifier = EmptyModifier
     /// The type of view this registry produces for loading views.
     ///
-    /// Generally, implementors will use an opaque return type on their ``loadingView(for:state:)-33lst`` implementations and this will be inferred automatically.
+    /// Generally, implementors will use an opaque return type on their ``loadingView(for:state:)-6jd3b`` implementations and this will be inferred automatically.
     associatedtype LoadingView: View = Never
     
     /// This method is called by LiveView Native when it needs to construct a custom view.
@@ -110,7 +120,7 @@ public protocol CustomRegistry {
     /// If you do not implement this method, the framework provides a loading view which displays a simple text representation of the state.
     ///
     /// - Parameter url: The URL of the view being connected to.
-    /// - Parameter state: The current state of the coordinator. This method is never called with ``LiveSessionCoordinator/State-swift.enum/connected``.
+    /// - Parameter state: The current state of the coordinator. This method is never called with ``LiveSessionState/connected``.
     @ViewBuilder
     static func loadingView(for url: URL, state: LiveSessionState) -> LoadingView
 }
@@ -152,5 +162,6 @@ extension CustomRegistry where ModifierType == EmptyRegistry.None, CustomModifie
     }
 }
 
+/// A root registry is a ``CustomRegistry`` type that can be used directly as the registry for a ``LiveSessionCoordinator``.
 public protocol RootRegistry: CustomRegistry where Root == Self {
 }

--- a/Sources/LiveViewNative/ViewTree.swift
+++ b/Sources/LiveViewNative/ViewTree.swift
@@ -14,7 +14,7 @@ public extension CodingUserInfoKey {
     static let liveContext = CodingUserInfoKey(rawValue: "LiveViewNative.liveContext")!
 }
 
-struct ViewTreeBuilder<R: CustomRegistry> {
+struct ViewTreeBuilder<R: RootRegistry> {
     func fromNodes(_ nodes: NodeChildrenSequence, coordinator: LiveViewCoordinator<R>, url: URL) -> some View {
         return fromNodes(nodes, context: LiveContext(coordinator: coordinator, url: url))
     }
@@ -118,7 +118,7 @@ extension ViewTreeBuilder {
     }
 }
 
-enum ModifierContainer<R: CustomRegistry>: Decodable {
+enum ModifierContainer<R: RootRegistry>: Decodable {
     case builtin(BuiltinRegistry.BuiltinModifier)
     case custom(R.CustomModifier)
     case error(ErrorModifier)
@@ -162,7 +162,7 @@ enum ModifierContainer<R: CustomRegistry>: Decodable {
 }
 
 // this view is required to to break the infinitely-recursive type that occurs if the body of this view is inlined into applyAttributes(_:context:)
-private struct ModifierApplicator<Parent: View, R: CustomRegistry>: View {
+private struct ModifierApplicator<Parent: View, R: RootRegistry>: View {
     let parent: Parent
     let modifiers: ArraySlice<ModifierContainer<R>>
     let context: LiveContext<R>
@@ -188,7 +188,7 @@ private extension View {
 
 // not fileprivate because it's used by LiveContext
 // this cannot be "NodeView" because it's used by forEach which requires element ids, which leaf nodes can't have
-internal struct ElementView<R: CustomRegistry>: View {
+internal struct ElementView<R: RootRegistry>: View {
     let element: ElementNode
     let context: LiveContext<R>
     

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Buttons/Button.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Buttons/Button.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct Button<R: CustomRegistry>: View {
+struct Button<R: RootRegistry>: View {
     @ObservedElement private var element: ElementNode
     private let context: LiveContext<R>
     // used internaly by PhxSubmitButton

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Indicators/Gauge.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Indicators/Gauge.swift
@@ -8,7 +8,7 @@
 #if !os(tvOS)
 import SwiftUI
 
-struct Gauge<R: CustomRegistry>: View {
+struct Gauge<R: RootRegistry>: View {
     @ObservedElement private var element: ElementNode
     let context: LiveContext<R>
     

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Indicators/ProgressView.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Indicators/ProgressView.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct ProgressView<R: CustomRegistry>: View {
+struct ProgressView<R: RootRegistry>: View {
     @ObservedElement private var element: ElementNode
     let context: LiveContext<R>
     

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Links/Link.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Links/Link.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct Link<R: CustomRegistry>: View {
+struct Link<R: RootRegistry>: View {
     @ObservedElement private var element: ElementNode
     let context: LiveContext<R>
     

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Links/ShareLink.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Links/ShareLink.swift
@@ -10,7 +10,7 @@ import LiveViewNativeCore
 import CoreTransferable
 
 
-struct ShareLink<R: CustomRegistry>: View {
+struct ShareLink<R: RootRegistry>: View {
     @ObservedElement private var element: ElementNode
     let context: LiveContext<R>
     

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Menus/Menu.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Menus/Menu.swift
@@ -7,7 +7,7 @@
 #if !os(watchOS)
 import SwiftUI
 
-struct Menu<R: CustomRegistry>: View {
+struct Menu<R: RootRegistry>: View {
     @ObservedElement private var element: ElementNode
     let context: LiveContext<R>
     

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Pickers/ColorPicker.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Pickers/ColorPicker.swift
@@ -8,7 +8,7 @@
 #if os(iOS) || os(macOS)
 import SwiftUI
 
-struct ColorPicker<R: CustomRegistry>: View {
+struct ColorPicker<R: RootRegistry>: View {
     @ObservedElement private var element: ElementNode
     let context: LiveContext<R>
     

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Pickers/DatePicker.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Pickers/DatePicker.swift
@@ -8,7 +8,7 @@
 #if os(iOS) || os(macOS)
 import SwiftUI
 
-struct DatePicker<R: CustomRegistry>: View {
+struct DatePicker<R: RootRegistry>: View {
     private let context: LiveContext<R>
     @ObservedElement private var element
     @FormState(default: CodableDate()) private var value: CodableDate

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Pickers/Picker.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Pickers/Picker.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct Picker<R: CustomRegistry>: View {
+struct Picker<R: RootRegistry>: View {
     private let context: LiveContext<R>
     @ObservedElement private var element
     @FormState private var value: String?

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Value Inputs/Slider.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Value Inputs/Slider.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct Slider<R: CustomRegistry>: View {
+struct Slider<R: RootRegistry>: View {
     @ObservedElement private var element: ElementNode
     let context: LiveContext<R>
     

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Value Inputs/Stepper.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Value Inputs/Stepper.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct Stepper<R: CustomRegistry>: View {
+struct Stepper<R: RootRegistry>: View {
     @ObservedElement private var element: ElementNode
     let context: LiveContext<R>
     

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Value Inputs/Toggle.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Value Inputs/Toggle.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct Toggle<R: CustomRegistry>: View {
+struct Toggle<R: RootRegistry>: View {
     @ObservedElement private var element: ElementNode
     let context: LiveContext<R>
     

--- a/Sources/LiveViewNative/Views/Drawing and Graphics/Color.swift
+++ b/Sources/LiveViewNative/Views/Drawing and Graphics/Color.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct Color<R: CustomRegistry>: View {
+struct Color<R: RootRegistry>: View {
     @ObservedElement private var element: ElementNode
     private let context: LiveContext<R>
     

--- a/Sources/LiveViewNative/Views/Images/AsyncImage.swift
+++ b/Sources/LiveViewNative/Views/Images/AsyncImage.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct AsyncImage<R: CustomRegistry>: View {
+struct AsyncImage<R: RootRegistry>: View {
     @ObservedElement private var element: ElementNode
     private let context: LiveContext<R>
     

--- a/Sources/LiveViewNative/Views/Images/Image.swift
+++ b/Sources/LiveViewNative/Views/Images/Image.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct Image<R: CustomRegistry>: View {
+struct Image<R: RootRegistry>: View {
     @ObservedElement private var observedElement: ElementNode
     private let overrideElement: ElementNode?
     private var element: ElementNode {

--- a/Sources/LiveViewNative/Views/Layout Containers/Collection Containers/List.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Collection Containers/List.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct List<R: CustomRegistry>: View {
+struct List<R: RootRegistry>: View {
     @ObservedElement private var element: ElementNode
     private let context: LiveContext<R>
     #if os(iOS) || os(tvOS)

--- a/Sources/LiveViewNative/Views/Layout Containers/Collection Containers/Section.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Collection Containers/Section.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct Section<R: CustomRegistry>: View {
+struct Section<R: RootRegistry>: View {
     @ObservedElement private var element: ElementNode
     private let context: LiveContext<R>
     

--- a/Sources/LiveViewNative/Views/Layout Containers/Collection Containers/Table.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Collection Containers/Table.swift
@@ -8,7 +8,7 @@
 #if os(iOS) || os(macOS)
 import SwiftUI
 
-struct Table<R: CustomRegistry>: View {
+struct Table<R: RootRegistry>: View {
     @ObservedElement private var element: ElementNode
     private let context: LiveContext<R>
     @Environment(\.coordinatorEnvironment) private var coordinatorEnvironment

--- a/Sources/LiveViewNative/Views/Layout Containers/Collection Containers/Table.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Collection Containers/Table.swift
@@ -14,7 +14,7 @@ struct Table<R: CustomRegistry>: View {
     @Environment(\.coordinatorEnvironment) private var coordinatorEnvironment
     
     @LiveBinding(attribute: "selection") private var selection = Selection.multiple([])
-    @LiveBinding(attribute: "sort-order") private var sortOrder = [ColumnSort]()
+    @LiveBinding(attribute: "sort-order") private var sortOrder = [TableColumnSort]()
     
     init(element: ElementNode, context: LiveContext<R>) {
         self.context = context
@@ -24,209 +24,94 @@ struct Table<R: CustomRegistry>: View {
         let rows = element.elementChildren()
             .filter { $0.tag == "rows" && $0.namespace == "table" }
             .flatMap { $0.elementChildren() }
-            .compactMap { $0.tag == "table-row" ? Row(element: $0) : nil }
+            .compactMap { $0.tag == "table-row" ? TableRow(element: $0) : nil }
         let columns = self.columns
         return SwiftUI.Group {
             switch columns.count {
             case 1:
-                switch selection {
-                case .single:
-                    SwiftUI.Table(rows, selection: $selection.single, sortOrder: $sortOrder) {
-                        columns[0]
-                    }
-                case .multiple:
-                    SwiftUI.Table(rows, selection: $selection.multiple, sortOrder: $sortOrder) {
-                        columns[0]
-                    }
+                SwiftUI.Table(rows: rows, selection: $selection, sortOrder: $sortOrder) {
+                    columns[0]
                 }
             case 2:
-                switch selection {
-                case .single:
-                    SwiftUI.Table(rows, selection: $selection.single, sortOrder: $sortOrder) {
-                        columns[0]
-                        columns[1]
-                    }
-                case .multiple:
-                    SwiftUI.Table(rows, selection: $selection.multiple, sortOrder: $sortOrder) {
-                        columns[0]
-                        columns[1]
-                    }
+                SwiftUI.Table(rows: rows, selection: $selection, sortOrder: $sortOrder) {
+                    columns[0]
+                    columns[1]
                 }
             case 3:
-                switch selection {
-                case .single:
-                    SwiftUI.Table(rows, selection: $selection.single, sortOrder: $sortOrder) {
-                        columns[0]
-                        columns[1]
-                        columns[2]
-                    }
-                case .multiple:
-                    SwiftUI.Table(rows, selection: $selection.multiple, sortOrder: $sortOrder) {
-                        columns[0]
-                        columns[1]
-                        columns[2]
-                    }
+                SwiftUI.Table(rows: rows, selection: $selection, sortOrder: $sortOrder) {
+                    columns[0]
+                    columns[1]
+                    columns[2]
                 }
             case 4:
-                switch selection {
-                case .single:
-                    SwiftUI.Table(rows, selection: $selection.single, sortOrder: $sortOrder) {
-                        columns[0]
-                        columns[1]
-                        columns[2]
-                        columns[3]
-                    }
-                case .multiple:
-                    SwiftUI.Table(rows, selection: $selection.multiple, sortOrder: $sortOrder) {
-                        columns[0]
-                        columns[1]
-                        columns[2]
-                        columns[3]
-                    }
+                SwiftUI.Table(rows: rows, selection: $selection, sortOrder: $sortOrder) {
+                    columns[0]
+                    columns[1]
+                    columns[2]
+                    columns[3]
                 }
             case 5:
-                switch selection {
-                case .single:
-                    SwiftUI.Table(rows, selection: $selection.single, sortOrder: $sortOrder) {
-                        columns[0]
-                        columns[1]
-                        columns[2]
-                        columns[3]
-                        columns[4]
-                    }
-                case .multiple:
-                    SwiftUI.Table(rows, selection: $selection.multiple, sortOrder: $sortOrder) {
-                        columns[0]
-                        columns[1]
-                        columns[2]
-                        columns[3]
-                        columns[4]
-                    }
+                SwiftUI.Table(rows: rows, selection: $selection, sortOrder: $sortOrder) {
+                    columns[0]
+                    columns[1]
+                    columns[2]
+                    columns[3]
+                    columns[4]
                 }
             case 6:
-                switch selection {
-                case .single:
-                    SwiftUI.Table(rows, selection: $selection.single, sortOrder: $sortOrder) {
-                        columns[0]
-                        columns[1]
-                        columns[2]
-                        columns[3]
-                        columns[4]
-                        columns[5]
-                    }
-                case .multiple:
-                    SwiftUI.Table(rows, selection: $selection.multiple, sortOrder: $sortOrder) {
-                        columns[0]
-                        columns[1]
-                        columns[2]
-                        columns[3]
-                        columns[4]
-                        columns[5]
-                    }
+                SwiftUI.Table(rows: rows, selection: $selection, sortOrder: $sortOrder) {
+                    columns[0]
+                    columns[1]
+                    columns[2]
+                    columns[3]
+                    columns[4]
+                    columns[5]
                 }
             case 7:
-                switch selection {
-                case .single:
-                    SwiftUI.Table(rows, selection: $selection.single, sortOrder: $sortOrder) {
-                        columns[0]
-                        columns[1]
-                        columns[2]
-                        columns[3]
-                        columns[4]
-                        columns[5]
-                        columns[6]
-                    }
-                case .multiple:
-                    SwiftUI.Table(rows, selection: $selection.multiple, sortOrder: $sortOrder) {
-                        columns[0]
-                        columns[1]
-                        columns[2]
-                        columns[3]
-                        columns[4]
-                        columns[5]
-                        columns[6]
-                    }
+                SwiftUI.Table(rows: rows, selection: $selection, sortOrder: $sortOrder) {
+                    columns[0]
+                    columns[1]
+                    columns[2]
+                    columns[3]
+                    columns[4]
+                    columns[5]
+                    columns[6]
                 }
             case 8:
-                switch selection {
-                case .single:
-                    SwiftUI.Table(rows, selection: $selection.single, sortOrder: $sortOrder) {
-                        columns[0]
-                        columns[1]
-                        columns[2]
-                        columns[3]
-                        columns[4]
-                        columns[5]
-                        columns[6]
-                        columns[7]
-                    }
-                case .multiple:
-                    SwiftUI.Table(rows, selection: $selection.multiple, sortOrder: $sortOrder) {
-                        columns[0]
-                        columns[1]
-                        columns[2]
-                        columns[3]
-                        columns[4]
-                        columns[5]
-                        columns[6]
-                        columns[7]
-                    }
+                SwiftUI.Table(rows: rows, selection: $selection, sortOrder: $sortOrder) {
+                    columns[0]
+                    columns[1]
+                    columns[2]
+                    columns[3]
+                    columns[4]
+                    columns[5]
+                    columns[6]
+                    columns[7]
                 }
             case 9:
-                switch selection {
-                case .single:
-                    SwiftUI.Table(rows, selection: $selection.single, sortOrder: $sortOrder) {
-                        columns[0]
-                        columns[1]
-                        columns[2]
-                        columns[3]
-                        columns[4]
-                        columns[5]
-                        columns[6]
-                        columns[7]
-                        columns[8]
-                    }
-                case .multiple:
-                    SwiftUI.Table(rows, selection: $selection.multiple, sortOrder: $sortOrder) {
-                        columns[0]
-                        columns[1]
-                        columns[2]
-                        columns[3]
-                        columns[4]
-                        columns[5]
-                        columns[6]
-                        columns[7]
-                        columns[8]
-                    }
+                SwiftUI.Table(rows: rows, selection: $selection, sortOrder: $sortOrder) {
+                    columns[0]
+                    columns[1]
+                    columns[2]
+                    columns[3]
+                    columns[4]
+                    columns[5]
+                    columns[6]
+                    columns[7]
+                    columns[8]
                 }
             case 10:
-                switch selection {
-                case .single:
-                    SwiftUI.Table(rows, selection: $selection.single, sortOrder: $sortOrder) {
-                        columns[0]
-                        columns[1]
-                        columns[2]
-                        columns[3]
-                        columns[4]
-                        columns[5]
-                        columns[6]
-                        columns[7]
-                        columns[8]
-                        columns[9]
-                    }
-                case .multiple:
-                    SwiftUI.Table(rows, selection: $selection.multiple, sortOrder: $sortOrder) {
-                        columns[0]
-                        columns[1]
-                        columns[2]
-                        columns[3]
-                        columns[4]
-                        columns[5]
-                        columns[6]
-                        columns[7]
-                        columns[8]
-                        columns[9]
-                    }
+                SwiftUI.Table(rows: rows, selection: $selection, sortOrder: $sortOrder) {
+                    columns[0]
+                    columns[1]
+                    columns[2]
+                    columns[3]
+                    columns[4]
+                    columns[5]
+                    columns[6]
+                    columns[7]
+                    columns[8]
+                    columns[9]
                 }
             default:
                 fatalError("Too many columns in table: \(columns.count)")
@@ -235,35 +120,14 @@ struct Table<R: CustomRegistry>: View {
         .applyTableStyle(element.attributeValue(for: "table-style").flatMap(TableStyle.init) ?? .automatic)
     }
     
-    private struct Row: Identifiable {
-        let element: ElementNode
-        var id: String {
-            guard let id = element.attributeValue(for: "id")
-            else { preconditionFailure("<table-row> must have an id") }
-            return id
-        }
-        
-        init(element: ElementNode) {
-            self.element = element
-        }
-    }
     
-    private struct ColumnSort: SortComparator, Codable, Equatable {
-        let id: String
-        var order: SortOrder
-        
-        func compare(_ lhs: Row, _ rhs: Row) -> ComparisonResult {
-            .orderedSame
-        }
-    }
-    
-    private var columns: [TableColumn<Row, ColumnSort, some View, SwiftUI.Text>] {
+    private var columns: [TableColumn<TableRow, TableColumnSort, some View, SwiftUI.Text>] {
         let columnElements = element.elementChildren()
             .filter { $0.tag == "columns" && $0.namespace == "table" }
             .flatMap { $0.elementChildren() }
             .filter { $0.tag == "table-column" }
         return columnElements.enumerated().map { item in
-            TableColumn(item.element.innerText(), sortUsing: ColumnSort(id: item.element.attributeValue(for: "id") ?? String(item.offset), order: .forward)) { (row: Row) in
+            TableColumn(item.element.innerText(), sortUsing: TableColumnSort(id: item.element.attributeValue(for: "id") ?? String(item.offset), order: .forward)) { (row: TableRow) in
                 let rowChildren = row.element.children()
                 if rowChildren.indices.contains(item.offset) {
                     context.coordinator.builder.fromNodes(
@@ -279,6 +143,44 @@ struct Table<R: CustomRegistry>: View {
                 ideal: item.element.attributeValue(for: "ideal-width").flatMap(Double.init(_:)).flatMap(CGFloat.init),
                 max: item.element.attributeValue(for: "max-width").flatMap(Double.init(_:)).flatMap(CGFloat.init)
             )
+        }
+    }
+}
+
+fileprivate struct TableRow: Identifiable {
+    let element: ElementNode
+    var id: String {
+        guard let id = element.attributeValue(for: "id")
+        else { preconditionFailure("<table-row> must have an id") }
+        return id
+    }
+    
+    init(element: ElementNode) {
+        self.element = element
+    }
+}
+
+fileprivate struct TableColumnSort: SortComparator, Codable, Equatable {
+    let id: String
+    var order: SortOrder
+    
+    func compare(_ lhs: TableRow, _ rhs: TableRow) -> ComparisonResult {
+        .orderedSame
+    }
+}
+
+fileprivate extension SwiftUI.Table where Value == TableRow, Rows == TableForEachContent<[TableRow]> {
+    init(
+        rows: [TableRow],
+        selection: Binding<Selection>,
+        sortOrder: Binding<[TableColumnSort]>,
+        @TableColumnBuilder<TableRow, TableColumnSort> columns: () -> Columns
+    ) {
+        switch selection.wrappedValue {
+        case .single(_):
+            self.init(rows, selection: selection.single, sortOrder: sortOrder, columns: columns)
+        case .multiple(_):
+            self.init(rows, selection: selection.multiple, sortOrder: sortOrder, columns: columns)
         }
     }
 }

--- a/Sources/LiveViewNative/Views/Layout Containers/Forms/Form.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Forms/Form.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct Form<R: CustomRegistry>: View {
+struct Form<R: RootRegistry>: View {
     @ObservedElement private var element
     private let context: LiveContext<R>
     

--- a/Sources/LiveViewNative/Views/Layout Containers/Forms/LabeledContent.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Forms/LabeledContent.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct LabeledContent<R: CustomRegistry>: View {
+struct LabeledContent<R: RootRegistry>: View {
     @ObservedElement private var element
     private let context: LiveContext<R>
     

--- a/Sources/LiveViewNative/Views/Layout Containers/Grids/Grid.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Grids/Grid.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct Grid<R: CustomRegistry>: View {
+struct Grid<R: RootRegistry>: View {
     @ObservedElement private var element: ElementNode
     private let context: LiveContext<R>
     

--- a/Sources/LiveViewNative/Views/Layout Containers/Grids/GridRow.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Grids/GridRow.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct GridRow<R: CustomRegistry>: View {
+struct GridRow<R: RootRegistry>: View {
     @ObservedElement private var element: ElementNode
     private let context: LiveContext<R>
     

--- a/Sources/LiveViewNative/Views/Layout Containers/Groups/ControlGroup.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Groups/ControlGroup.swift
@@ -8,7 +8,7 @@
 #if os(iOS) || os(macOS)
 import SwiftUI
 
-struct ControlGroup<R: CustomRegistry>: View {
+struct ControlGroup<R: RootRegistry>: View {
     @ObservedElement private var element: ElementNode
     private let context: LiveContext<R>
 

--- a/Sources/LiveViewNative/Views/Layout Containers/Groups/DisclosureGroup.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Groups/DisclosureGroup.swift
@@ -8,7 +8,7 @@
 #if os(iOS) || os(macOS)
 import SwiftUI
 
-struct DisclosureGroup<R: CustomRegistry>: View {
+struct DisclosureGroup<R: RootRegistry>: View {
     @ObservedElement private var element: ElementNode
     private let context: LiveContext<R>
     

--- a/Sources/LiveViewNative/Views/Layout Containers/Groups/Group.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Groups/Group.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct Group<R: CustomRegistry>: View {
+struct Group<R: RootRegistry>: View {
     @ObservedElement private var element: ElementNode
     private let context: LiveContext<R>
     

--- a/Sources/LiveViewNative/Views/Layout Containers/Groups/GroupBox.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Groups/GroupBox.swift
@@ -8,7 +8,7 @@
 #if os(iOS) || os(macOS)
 import SwiftUI
 
-struct GroupBox<R: CustomRegistry>: View {
+struct GroupBox<R: RootRegistry>: View {
     @ObservedElement private var element: ElementNode
     private let context: LiveContext<R>
 

--- a/Sources/LiveViewNative/Views/Layout Containers/Lazy Grids/LazyHGrid.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Lazy Grids/LazyHGrid.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct LazyHGrid<R: CustomRegistry>: View {
+struct LazyHGrid<R: RootRegistry>: View {
     @ObservedElement private var element: ElementNode
     private let context: LiveContext<R>
     

--- a/Sources/LiveViewNative/Views/Layout Containers/Lazy Grids/LazyVGrid.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Lazy Grids/LazyVGrid.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct LazyVGrid<R: CustomRegistry>: View {
+struct LazyVGrid<R: RootRegistry>: View {
     @ObservedElement private var element: ElementNode
     private let context: LiveContext<R>
     

--- a/Sources/LiveViewNative/Views/Layout Containers/Lazy Stacks/LazyHStack.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Lazy Stacks/LazyHStack.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct LazyHStack<R: CustomRegistry>: View {
+struct LazyHStack<R: RootRegistry>: View {
     @ObservedElement private var element: ElementNode
     private let context: LiveContext<R>
     

--- a/Sources/LiveViewNative/Views/Layout Containers/Lazy Stacks/LazyVStack.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Lazy Stacks/LazyVStack.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct LazyVStack<R: CustomRegistry>: View {
+struct LazyVStack<R: RootRegistry>: View {
     @ObservedElement private var element: ElementNode
     private let context: LiveContext<R>
     

--- a/Sources/LiveViewNative/Views/Layout Containers/Presentation Containers/NavigationLink.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Presentation Containers/NavigationLink.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import Combine
 
 @available(iOS 16.0, *)
-struct NavigationLink<R: CustomRegistry>: View {
+struct NavigationLink<R: RootRegistry>: View {
     @ObservedElement private var element: ElementNode
     private let context: LiveContext<R>
     @EnvironmentObject private var navCoordinator: NavigationCoordinator<R>

--- a/Sources/LiveViewNative/Views/Layout Containers/Scroll Views/ScrollView.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Scroll Views/ScrollView.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct ScrollView<R: CustomRegistry>: View {
+struct ScrollView<R: RootRegistry>: View {
     @ObservedElement private var element: ElementNode
     private let context: LiveContext<R>
     

--- a/Sources/LiveViewNative/Views/Layout Containers/Separators/Spacer.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Separators/Spacer.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct Spacer: View {
     @ObservedElement private var element: ElementNode
     
-    init(element: ElementNode, context: LiveContext<some CustomRegistry>) {
+    init(element: ElementNode, context: LiveContext<some RootRegistry>) {
     }
     
     public var body: some View {

--- a/Sources/LiveViewNative/Views/Layout Containers/Sizing/ViewThatFits.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Sizing/ViewThatFits.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct ViewThatFits<R: CustomRegistry>: View {
+struct ViewThatFits<R: RootRegistry>: View {
     @ObservedElement private var element: ElementNode
     private let context: LiveContext<R>
     

--- a/Sources/LiveViewNative/Views/Layout Containers/Stacks/HStack.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Stacks/HStack.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct HStack<R: CustomRegistry>: View {
+struct HStack<R: RootRegistry>: View {
     @ObservedElement private var element: ElementNode
     private let context: LiveContext<R>
     

--- a/Sources/LiveViewNative/Views/Layout Containers/Stacks/VStack.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Stacks/VStack.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct VStack<R: CustomRegistry>: View {
+struct VStack<R: RootRegistry>: View {
     @ObservedElement private var element: ElementNode
     private let context: LiveContext<R>
     

--- a/Sources/LiveViewNative/Views/Layout Containers/Stacks/ZStack.swift
+++ b/Sources/LiveViewNative/Views/Layout Containers/Stacks/ZStack.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct ZStack<R: CustomRegistry>: View {
+struct ZStack<R: RootRegistry>: View {
     @ObservedElement private var element: ElementNode
     private let context: LiveContext<R>
     

--- a/Sources/LiveViewNative/Views/PhxForm.swift
+++ b/Sources/LiveViewNative/Views/PhxForm.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct PhxForm<R: CustomRegistry>: View {
+struct PhxForm<R: RootRegistry>: View {
     @ObservedElement private var element: ElementNode
     private let context: LiveContext<R>
     

--- a/Sources/LiveViewNative/Views/PhxSubmitButton.swift
+++ b/Sources/LiveViewNative/Views/PhxSubmitButton.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct PhxSubmitButton<R: CustomRegistry>: View {
+struct PhxSubmitButton<R: RootRegistry>: View {
     @ObservedElement private var element: ElementNode
     private let context: LiveContext<R>
     private let formModel: FormModel

--- a/Sources/LiveViewNative/Views/Shapes/Shape.swift
+++ b/Sources/LiveViewNative/Views/Shapes/Shape.swift
@@ -11,7 +11,7 @@ struct Shape<S: SwiftUI.Shape>: View {
     @ObservedElement private var element: ElementNode
     private let shape: S
     
-    init(element: ElementNode, context: LiveContext<some CustomRegistry>, shape: S) {
+    init(element: ElementNode, context: LiveContext<some RootRegistry>, shape: S) {
         self.shape = shape
     }
     

--- a/Sources/LiveViewNative/Views/Text Input and Output/Label.swift
+++ b/Sources/LiveViewNative/Views/Text Input and Output/Label.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct Label<R: CustomRegistry>: View {
+struct Label<R: RootRegistry>: View {
     @ObservedElement private var element: ElementNode
     let context: LiveContext<R>
     

--- a/Sources/LiveViewNative/Views/Text Input and Output/SecureField.swift
+++ b/Sources/LiveViewNative/Views/Text Input and Output/SecureField.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct SecureField<R: CustomRegistry>: TextFieldProtocol {
+struct SecureField<R: RootRegistry>: TextFieldProtocol {
     @ObservedElement var element: ElementNode
     let context: LiveContext<R>
     @FormState var value: String?

--- a/Sources/LiveViewNative/Views/Text Input and Output/Text.swift
+++ b/Sources/LiveViewNative/Views/Text Input and Output/Text.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct Text<R: CustomRegistry>: View {
+struct Text<R: RootRegistry>: View {
     let context: LiveContext<R>
     
     // The view that's in the SwiftUI view tree needs to observe an element to respond to DOM changes,

--- a/Sources/LiveViewNative/Views/Text Input and Output/TextEditor.swift
+++ b/Sources/LiveViewNative/Views/Text Input and Output/TextEditor.swift
@@ -8,7 +8,7 @@
 #if os(iOS) || os(macOS)
 import SwiftUI
 
-struct TextEditor<R: CustomRegistry>: TextFieldProtocol {
+struct TextEditor<R: RootRegistry>: TextFieldProtocol {
     @ObservedElement var element: ElementNode
     let context: LiveContext<R>
     @FormState var value: String?

--- a/Sources/LiveViewNative/Views/Text Input and Output/TextField.swift
+++ b/Sources/LiveViewNative/Views/Text Input and Output/TextField.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct TextField<R: CustomRegistry>: TextFieldProtocol {
+struct TextField<R: RootRegistry>: TextFieldProtocol {
     @ObservedElement var element: ElementNode
     let context: LiveContext<R>
     @FormState var value: String?

--- a/Sources/LiveViewNative/Views/Text Input and Output/TextFieldProtocol.swift
+++ b/Sources/LiveViewNative/Views/Text Input and Output/TextFieldProtocol.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 protocol TextFieldProtocol: View {
-    associatedtype R: CustomRegistry
+    associatedtype R: RootRegistry
     var element: ElementNode { get }
     var context: LiveContext<R> { get }
     var value: String? { get nonmutating set }


### PR DESCRIPTION
Allows composing multiple custom registry types, in preparation for the form components to be extracted out.

Usage:
```swift
struct AppRegistries: AggregateRegistry {
    typealias Registries = Registry3<
        MyRegistry<Self>,
        OtherRegistry<Self>,
        ThirdRegistry<Self>
    >
}
struct MyRegistry<Root: RootRegistry>: CustomRegistry {
    // ...
}
// ...

struct ContentView: View {
    @State private var session = LiveSessionCoordinator<AppRegistries>(URL(string: "http://localhost:4000")!)
    // ...
}
```

This also introduces the concept of a "root" registry, which is the registry type that's passed in to the LiveSessionCoordinator. Registries that can be composed need to be generic over the root type, as shown above, because a view created by one sub-registry needs to be able to create views from elements that are part of other sub-registries.

Unfortunately the result builder syntax proposed in #178 is not possible (inferring the associated type from the opaque result type just doesn't work, so you have to spell out the typealias anyways. I suspect this is a compiler bug).