### PR TITLE
Add TextFieldLink

### DIFF
--- a/Sources/LiveViewNative/Registries/BuiltinRegistry.swift
+++ b/Sources/LiveViewNative/Registries/BuiltinRegistry.swift
@@ -134,6 +134,10 @@ struct BuiltinRegistry: BuiltinRegistryProtocol {
 #endif
         case "text-field":
             TextField<R>(element: element, context: context)
+#if os(watchOS)
+        case "text-field-link":
+            TextFieldLink(context: context)
+#endif
         case "toggle":
             Toggle(element: element, context: context)
         case "v-stack", "vstack":

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Links/TextFieldLink.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Links/TextFieldLink.swift
@@ -1,0 +1,30 @@
+//
+//  TextFieldLink.swift
+//  
+//
+//  Created by Carson Katri on 3/2/23.
+//
+
+#if os(watchOS)
+import SwiftUI
+
+struct TextFieldLink<R: RootRegistry>: View {
+    @ObservedElement var element: ElementNode
+    let context: LiveContext<R>
+    @FormState var value: String?
+    
+    init(context: LiveContext<R>) {
+        self.context = context
+    }
+    
+    var body: some View {
+        SwiftUI.TextFieldLink(
+            prompt: element.attributeValue(for: "prompt").flatMap(SwiftUI.Text.init)
+        ) {
+            context.buildChildren(of: element)
+        } onSubmit: { newValue in
+            value = newValue
+        }
+    }
+}
+#endif


### PR DESCRIPTION
Closes #66 

This View is only available on watchOS. When tapped, a watchOS text input will be presented, and when closed the value is sent to the server, either to a form or binding.

```html
<scroll-view>
  <phx-form id="my-form" phx-submit="send_message">
    <text-field-link name="body">
      Message
    </text-field-link>
    <phx-submit-button modifiers={@native |> tint(color: "system-blue")}>Send</phx-submit-button>
  </phx-form>
  <divider modifiers={@native |> padding(all: 8)} />
  <v-stack>
    <v-stack>
      <%= for message <- @messages do %>
        <text id={message.id}><%= message.body %></text>
      <% end %>
    </v-stack>
  </v-stack>
</scroll-view>
```

https://user-images.githubusercontent.com/13581484/222529279-4ff68ed4-db65-4601-91f8-504feb98234a.mp4

