### PR TITLE
Add PasteButton

### DIFF
--- a/Sources/LiveViewNative/Registries/BuiltinRegistry.swift
+++ b/Sources/LiveViewNative/Registries/BuiltinRegistry.swift
@@ -100,6 +100,10 @@ struct BuiltinRegistry: BuiltinRegistryProtocol {
 #endif
         case "navigation-link":
             NavigationLink(element: element, context: context)
+#if os(iOS) || os(macOS)
+        case "paste-button":
+            PasteButton(context: context)
+#endif
         case "progress-view":
             ProgressView(element: element, context: context)
         case "picker":

--- a/Sources/LiveViewNative/Views/Controls and Indicators/Buttons/PasteButton.swift
+++ b/Sources/LiveViewNative/Views/Controls and Indicators/Buttons/PasteButton.swift
@@ -1,0 +1,28 @@
+//
+//  PasteButton.swift
+//  
+//
+//  Created by Carson Katri on 3/2/23.
+//
+#if os(iOS) || os(macOS)
+import SwiftUI
+
+struct PasteButton<R: RootRegistry>: View {
+    @ObservedElement private var element
+    private let context: LiveContext<R>
+    
+    init(context: LiveContext<R>) {
+        self.context = context
+    }
+    
+    var body: some View {
+        SwiftUI.PasteButton(payloadType: String.self) { strings in
+            guard let clickEvent = element.attributeValue(for: "phx-click")
+            else { return }
+            Task {
+                try await context.coordinator.pushEvent(type: "click", event: clickEvent, value: ["value": strings])
+            }
+        }
+    }
+}
+#endif


### PR DESCRIPTION
Closes #62 

`PasteButton` doesn't seem to render in snapshot tests, so I haven't included one. I'm not sure why it doesn't though.

When #159 is merged I will update this to use the `@Event` wrapper for throttle/debounce/component support.

Currently this only supports pasting strings. It returns an array of strings to the event set with `phx-click`.

```html
<text><%= @pasted_value %></text>
<paste-button phx-click="paste_value" />
```

```ex
def handle_event("paste_value", %{ "value" => value }, socket) do
  {:noreply, assign(socket, :pasted_value, hd(value))}
end
```

https://user-images.githubusercontent.com/13581484/222542188-f6f3b666-3abf-4f8c-a320-ec91e712dce2.mp4

