### PR TITLE
Add `RenameButton` and `renameAction`

### DIFF
--- a/Sources/LiveViewNative/Modifiers/RenameActionModifier.swift
+++ b/Sources/LiveViewNative/Modifiers/RenameActionModifier.swift
@@ -1,0 +1,35 @@
+//
+//  RenameActionModifier.swift
+//  LiveViewNative
+//
+//  Created by Carson Katri on 3/3/23.
+//
+
+import SwiftUI
+
+struct RenameActionModifier: ViewModifier, Decodable {
+    private let event: String
+    private let target: Int?
+    @Environment(\.coordinatorEnvironment) private var coordinatorEnvironment
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.event = try container.decode(String.self, forKey: .event)
+        self.target = try container.decode(Int?.self, forKey: .target)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case event
+        case target
+    }
+    
+    func body(content: Content) -> some View {
+        content
+            .renameAction {
+                Task {
+                    // FIXME: Pass the target once that is available.
+                    try await coordinatorEnvironment?.pushEvent("click", event, [String:Any]())
+                }
+            }
+    }
+}

--- a/Sources/LiveViewNative/Registries/BuiltinRegistry.swift
+++ b/Sources/LiveViewNative/Registries/BuiltinRegistry.swift
@@ -106,6 +106,8 @@ struct BuiltinRegistry: BuiltinRegistryProtocol {
             Picker(context: context)
         case "rectangle":
             Shape(element: element, context: context, shape: Rectangle())
+        case "rename-button":
+            RenameButton()
         case "rounded-rectangle":
             Shape(element: element, context: context, shape: RoundedRectangle(from: element))
         case "scroll-view":
@@ -163,6 +165,7 @@ struct BuiltinRegistry: BuiltinRegistryProtocol {
         case listRowSeparator = "list_row_separator"
         case navigationTitle = "navigation_title"
         case padding
+        case renameAction = "rename_action"
         case tag
         case tint
     }
@@ -190,6 +193,8 @@ struct BuiltinRegistry: BuiltinRegistryProtocol {
             try NavigationTitleModifier(from: decoder)
         case .padding:
             try PaddingModifier(from: decoder)
+        case .renameAction:
+            try RenameActionModifier(from: decoder)
         case .tag:
             try TagModifier(from: decoder)
         case .tint:

--- a/Tests/RenderingTests/ButtonTests.swift
+++ b/Tests/RenderingTests/ButtonTests.swift
@@ -57,4 +57,14 @@ final class ButtonTests: XCTestCase {
                 .buttonStyle(.plain)
         }
     }
+
+    func testRenameButton() throws {
+        try assertMatch(#"<rename-button />"#) {
+            RenameButton()
+        }
+        try assertMatch(#"<rename-button modifiers='[{"type":"rename_action","event":"rename","target":null}]' />"#) {
+            RenameButton()
+                .renameAction {}
+        }
+    }
 }

--- a/lib/live_view_native_swift_ui/modifiers/rename_action.ex
+++ b/lib/live_view_native_swift_ui/modifiers/rename_action.ex
@@ -1,0 +1,8 @@
+defmodule LiveViewNativeSwiftUi.Modifiers.RenameAction do
+  use LiveViewNativePlatform.Modifier
+
+  modifier_schema "rename_action" do
+    field :event, :string
+    field :target, :integer
+  end
+end

--- a/lib/live_view_native_swift_ui/platform.ex
+++ b/lib/live_view_native_swift_ui/platform.ex
@@ -36,7 +36,9 @@ defmodule LiveViewNativeSwiftUi.Platform do
           grid_cell_anchor: Modifiers.GridCellAnchor,
           grid_cell_columns: Modifiers.GridCellColumns,
           grid_cell_unsized_axes: Modifiers.GridCellUnsizedAxes,
-          grid_column_alignment: Modifiers.GridColumnAlignment
+          grid_column_alignment: Modifiers.GridColumnAlignment,
+
+          rename_action: Modifiers.RenameAction
         ],
         template_engine: LiveViewNative.Engine,
         template_namespace: SwiftUi


### PR DESCRIPTION
This adds the `rename-button` View and associated `rename_action` modifier. When clicked, the button will trigger the event specified by `rename_action`, which can be declared on any of its parent Views.

> **Note** Support for the `target` option is waiting on #166 

Alternatively, `<rename-button>` could be implemented with the event being specified on its element with `phx-click`. However, this deviates from how SwiftUI declares this type of button. I assume they designed it like this because rename buttons often appear in multiple places but should trigger the same action?

```html
<text>
  <%= if @is_on do %>
    Renaming
  <% else %>
    Not Renaming
  <% end %>
</text>
<v-stack modifiers={@native |> rename_action(event: "rename")}>
  <rename-button />
</v-stack>
```

https://user-images.githubusercontent.com/13581484/222753592-06858d37-2d5a-478d-9afd-d983bd942c0b.mp4

